### PR TITLE
Reduced calls to branch listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 * @edgardmessias Fixed config option form svn path
 * @JohnstonCode Fixed conflicted files not having an icon
+* @edgardmessias Reduced calls to branch listings
 
 # **v1.3.2**
 


### PR DESCRIPTION
Currently, each save, it generates a list request of branches.

This pull request solves the issue