### PR TITLE
Added to ignore .git and .hg in multiple folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
           "type": "array",
           "minimum": 4,
           "description": "Folders to ignore using SVN",
-          "default": ["**/vendor", "**/node_modules"]
+          "default": ["**/.git", "**/.hg", "**/vendor", "**/node_modules"]
         }
       }
     }


### PR DESCRIPTION
If the config "svn.multipleFolders.ignore" is globally true, on open a git project, High CPU usage