### PR TITLE
Fixed commit when message is a existent file (Close #221)

### DIFF
--- a/src/svn.ts
+++ b/src/svn.ts
@@ -177,8 +177,9 @@ export class Svn {
     }
 
     if (options.log !== false) {
+      const argsOut = args.map(arg => (/ /.test(arg) ? `'${arg}'` : arg));
       this.logOutput(
-        `[${this.lastCwd.split(/[\\\/]+/).pop()}]$ svn ${args.join(" ")}\n`
+        `[${this.lastCwd.split(/[\\\/]+/).pop()}]$ svn ${argsOut.join(" ")}\n`
       );
     }
 

--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -4,6 +4,7 @@ import { IFileStatus, parseStatusXml } from "./statusParser";
 import { parseInfoXml, ISvnInfo } from "./infoParser";
 import { sequentialize } from "./decorators";
 import * as path from "path";
+import * as fs from "fs";
 import { fixPathSeparator } from "./util";
 import { configuration } from "./helpers/configuration";
 import { parseSvnList } from "./listParser";
@@ -115,7 +116,14 @@ export class Repository {
   async commitFiles(message: string, files: string[]) {
     files = files.map(file => this.removeAbsolutePath(file));
 
-    const result = await this.exec(["commit", "-m", message, ...files]);
+    const args = ["commit", ...files];
+
+    if (fs.existsSync(path.join(this.workspaceRoot, message))) {
+      args.push("--force-log");
+    }
+    args.push("-m", message);
+
+    const result = await this.exec(args);
 
     const matches = result.stdout.match(/Committed revision (.*)\./i);
     if (matches && matches[0]) {


### PR DESCRIPTION
See http://svnbook.red-bean.com/en/1.8/svn.ref.svn.html#svn.ref.svn.sw.force_log

Note: SVN log show quotes for arguments if contains space.
Old: `svn commit -m test message readme.md`
New: `svn commit -m 'test message' readme.md`