### PR TITLE
Added configuration parameter svn.default.encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@types/xml2js": "^0.4.2",
     "iconv-lite": "^0.4.19",
+    "is-utf8": "^0.2.1",
     "jschardet": "^1.6.0",
     "micromatch": "^3.1.5",
     "xml2js": "^0.4.19"
@@ -596,6 +597,14 @@
           "type": "boolean",
           "description": "Set file to status resolved after fix conflictss",
           "default": false
+        },
+        "svn.default.encoding": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Encoding of svn output if the output is not utf-8. When this parameter is null, the encoding is automatically detected. Example: 'windows-1252'.",
+          "default": null
         }
       }
     }

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -8,6 +8,9 @@ import { Repository } from "./svnRepository";
 import { parseInfoXml } from "./infoParser";
 import { SpawnOptions } from "child_process";
 import { IDisposable, toDisposable, dispose } from "./util";
+import { configuration } from "./helpers/configuration";
+
+const isUtf8 = require("is-utf8");
 
 // List: https://github.com/apache/subversion/blob/1.6.x/subversion/svn/schema/status.rnc#L33
 export enum Status {
@@ -241,15 +244,30 @@ export class Svn {
 
     // SVN with '--xml' always return 'UTF-8', and jschardet detects this encoding: 'TIS-620'
     if (!args.includes("--xml")) {
-      jschardet.MacCyrillicModel.mTypicalPositiveRatio += 0.001;
 
-      const encodingGuess = jschardet.detect(stdout);
+      const default_encoding = configuration.get<string>("default.encoding");
+      if (default_encoding) {
+        if (!iconv.encodingExists(default_encoding)) {
+          this.logOutput("svn.default.encoding: Invalid Parameter: '" + default_encoding + "'.\n")
+        } else if (!isUtf8(stdout)) {
+          encoding = default_encoding;
+          console.info("encoding: " + encoding)
+        } else {
+          console.info("encoding is UTF-8");
+        }
 
-      if (
-        encodingGuess.confidence > 0.8 &&
-        iconv.encodingExists(encodingGuess.encoding)
-      ) {
-        encoding = encodingGuess.encoding;
+      } else {
+
+        jschardet.MacCyrillicModel.mTypicalPositiveRatio += 0.001;
+
+        const encodingGuess = jschardet.detect(stdout);
+
+        if (
+          encodingGuess.confidence > 0.8 &&
+          iconv.encodingExists(encodingGuess.encoding)
+        ) {
+          encoding = encodingGuess.encoding;
+        }
       }
     }
 

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -251,9 +251,6 @@ export class Svn {
           this.logOutput("svn.default.encoding: Invalid Parameter: '" + default_encoding + "'.\n")
         } else if (!isUtf8(stdout)) {
           encoding = default_encoding;
-          console.info("encoding: " + encoding)
-        } else {
-          console.info("encoding is UTF-8");
         }
 
       } else {


### PR DESCRIPTION
Added configuration parameter svn.default.encoding:
Encoding of svn output if the output is not utf-8. When this parameter is null, the encoding is automatically detected. Example: 'svn.default.encoding: windows-1252'.