### PR TITLE
Fixed error: ENOENT: no such file or directory

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -522,7 +522,10 @@ export class SvnCommands implements IDisposable {
       return;
     }
 
-    if (fs.statSync(right.fsPath).isDirectory()) {
+    if (
+      fs.existsSync(right.fsPath) &&
+      fs.statSync(right.fsPath).isDirectory()
+    ) {
       return;
     }
 


### PR DESCRIPTION
If file is deleted or renamed, in console error show `ENOENT: no such file or directory`