### PR TITLE
Use the "files.encoding" for default encoding

### DIFF
--- a/src/svn.ts
+++ b/src/svn.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "events";
 import * as iconv from "iconv-lite";
 import isUtf8 = require("is-utf8");
 import * as jschardet from "jschardet";
+import { workspace } from "vscode";
 import { ICpOptions, IExecutionResult, ISvnOptions } from "./common/types";
 import { configuration } from "./helpers/configuration";
 import { parseInfoXml } from "./infoParser";
@@ -137,10 +138,14 @@ export class Svn {
 
     dispose(disposables);
 
-    let encoding = "utf8";
+    let encoding = workspace
+      .getConfiguration("files")
+      .get<string>("encoding", "utf8");
 
     // SVN with '--xml' always return 'UTF-8', and jschardet detects this encoding: 'TIS-620'
-    if (!args.includes("--xml")) {
+    if (args.includes("--xml")) {
+      encoding = "utf8";
+    } else {
       const defaultEncoding = configuration.get<string>("default.encoding");
       if (defaultEncoding) {
         if (!iconv.encodingExists(defaultEncoding)) {


### PR DESCRIPTION
Some users change the default `files.encoding`.

With this pull, not need change the `svn.default.encoding` in some cases