### PR TITLE
Added check for old working copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -546,6 +546,11 @@
           "description": "Ignores the warning when SVN is missing",
           "default": false
         },
+        "svn.ignoreWorkingCopyIsTooOld": {
+          "type": "boolean",
+          "description": "Ignores the warning when working copy is too old",
+          "default": false
+        },
         "svn.diff.withHead": {
           "type": "boolean",
           "description":

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -15,7 +15,8 @@ export const svnErrorCodes: { [key: string]: string } = {
   AuthorizationFailed: "E170001",
   RepositoryIsLocked: "E155004",
   NotASvnRepository: "E155007",
-  NotShareCommonAncestry: "E195012"
+  NotShareCommonAncestry: "E195012",
+  WorkingCopyIsTooOld: "E155036"
 };
 
 function getSvnErrorCode(stderr: string): string | undefined {
@@ -206,6 +207,9 @@ export class Svn {
       // SVN 1.6 not has "wcroot-abspath"
       return path;
     } catch (error) {
+      if (error instanceof SvnError) {
+        throw error;
+      }
       console.error(error);
       throw new Error("Unable to find repository root path");
     }


### PR DESCRIPTION
If working copy is old (Ex. 1.6) and the client is new (Ex. 1.9), show a prompt to upgrade the working copy