### PR TITLE
feat: Added refresh button for remote changes (#366)

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,15 @@
         }
       },
       {
+        "command": "svn.refreshRemoteChanges",
+        "title": "Refresh Remote Changes",
+        "category": "SVN",
+        "icon": {
+          "light": "icons/light/refresh.svg",
+          "dark": "icons/dark/refresh.svg"
+        }
+      },
+      {
         "command": "svn.switchBranch",
         "title": "Switch Branch",
         "category": "SVN"
@@ -446,7 +455,18 @@
           "when": "scmProvider == svn"
         }
       ],
-      "scm/resourceGroup/context": [],
+      "scm/resourceGroup/context": [
+        {
+          "command": "svn.refreshRemoteChanges",
+          "when": "config.svn.enabled && scmProvider == svn && scmResourceGroup == remotechanges",
+          "group": "inline"
+        },
+        {
+          "command": "svn.refreshRemoteChanges",
+          "when": "config.svn.enabled && scmProvider == svn && scmResourceGroup == remotechanges",
+          "group": "navigation"
+        }
+      ],
       "scm/resourceState/context": [
         {
           "command": "svn.add",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -508,6 +508,11 @@ export class SvnCommands implements IDisposable {
     }
   }
 
+  @command("svn.refreshRemoteChanges", { repository: true })
+  public async refreshRemoteChanges(repository: Repository) {
+    await repository.updateRemoteChangedFiles();
+  }
+
   @command("svn.openResourceBase")
   public async openResourceBase(resource: Resource): Promise<void> {
     await this._openResource(resource, "BASE", undefined, true, false);


### PR DESCRIPTION
A alternative for `svn.refresh.remoteChanges` option