### PR TITLE
Don't include *.map in extension bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,4 @@ src/**
 test/**
 tsconfig.json
 vsc-extension-quickstart.md
+**/*.map


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/62687

Don't include `*.map` files in the VS Code extension bundle vsix