### PR TITLE
fix: Fixed credentials for remote changes (Close #401)

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -449,10 +449,12 @@ export class Repository {
     );
 
     const statuses =
-      (await this.repository.getStatus({
-        includeIgnored: true,
-        includeExternals: combineExternal,
-        checkRemoteChanges
+      (await this.retryRun(async () => {
+        return await this.repository.getStatus({
+          includeIgnored: true,
+          includeExternals: combineExternal,
+          checkRemoteChanges
+        });
       })) || [];
 
     const fileConfig = workspace.getConfiguration("files", Uri.file(this.root));

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -106,6 +106,9 @@ export class Svn {
       args.push("--password", options.password);
     }
 
+    // Force non interactive environment
+    args.push("--non-interactive");
+
     let encoding = options.encoding || "utf8";
     delete options.encoding;
 


### PR DESCRIPTION
For remote operations in `repository.ts` we need use the `retryRun`