### PR TITLE
test: Fixed Mocha deprecated warning

### DIFF
--- a/src/test/istanbultestrunner.ts
+++ b/src/test/istanbultestrunner.ts
@@ -27,14 +27,18 @@ if (!tty.getWindowSize) {
 }
 
 let mocha = new Mocha({
-  ui: "tdd",
-  useColors: true
+  ui: "tdd"
 });
 
 let testOptions: any;
 
 export function configure(mochaOpts: Mocha.MochaOptions, testOpts: any): void {
+  // For Mocha >= 6.0.0, `useColors` is deprecated
+  const color = mochaOpts.useColors || (<any>mochaOpts).color || false;
+  delete mochaOpts.useColors;
+
   mocha = new Mocha(mochaOpts);
+  mocha.useColors(color);
   testOptions = testOpts;
 }
 


### PR DESCRIPTION
Fixed the message: `useColors is DEPRECATED and will be removed from a future version of Mocha. Instead, use the "color" option`

Note: current Mocha is 6.0.2, but, the latest `@types/mocha` is 5.2.6