### PR TITLE
test: Fixed spawn ENOENT for svnRepository.test.ts

### DIFF
--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -35,11 +35,9 @@ export class Repository {
     policy: ConstructorPolicy
   ) {
     if (policy === ConstructorPolicy.LateInit) {
-      console.error(
-        "Constructor called in sync fashion, test-only\n",
-        new Error().stack
-      );
-      return;
+      return ((async (): Promise<Repository> => {
+        return this;
+      })() as unknown) as Repository;
     }
     return ((async (): Promise<Repository> => {
       await this.updateInfo();

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -17,6 +17,7 @@ import { ISvnResourceGroup } from "../common/types";
 import { Model } from "../model";
 import { Repository } from "../repository";
 import * as testUtil from "./testUtil";
+import { timeout } from "../util";
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Commands Tests", () => {
@@ -174,6 +175,9 @@ suite("Commands Tests", () => {
     testUtil.overrideNextShowInputBox("Created new branch test");
     await commands.executeCommand("svn.switchBranch");
 
+    // Wait run updateRemoteChangedFiles
+    await timeout(2000);
+
     const repository = model.getRepository(checkoutDir) as Repository;
     assert.equal(await repository.getCurrentBranch(), "branches/test");
   });
@@ -181,6 +185,9 @@ suite("Commands Tests", () => {
   test("Switch Branch", async function() {
     testUtil.overrideNextShowQuickPick(2);
     await commands.executeCommand("svn.switchBranch");
+
+    // Wait run updateRemoteChangedFiles
+    await timeout(2000);
 
     const repository = model.getRepository(checkoutDir) as Repository;
     assert.equal(await repository.getCurrentBranch(), "trunk");


### PR DESCRIPTION
Fix the message:

```
Tests exited with code: 0
stack trace: Error: spawn /usr/local/bin/svn ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:229:19)
    at onErrorNT (internal/child_process.js:406:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)

Constructor called in sync fashion, test-only
 Error
    at new Repository (/Users/vsts/agent/2.148.1/work/1/s/out/svnRepository.js:9:4963)
    at Object.<anonymous> (/Users/vsts/agent/2.148.1/work/1/s/src/test/svnRepository.test.ts:23:30)
    at Generator.next (<anonymous>)
    at __awaiter (/Users/vsts/agent/2.148.1/work/1/s/out/test/svnRepository.test.js:7:71)
    at new Promise (<anonymous>)
    at __awaiter (/Users/vsts/agent/2.148.1/work/1/s/out/test/svnRepository.test.js:3:12)
    at Context.test (/Users/vsts/agent/2.148.1/work/1/s/src/test/svnRepository.test.ts:21:37)
    at callFn (/Users/vsts/agent/2.148.1/work/1/s/node_modules/mocha/lib/runnable.js:387:21)
    at Test.Runnable.run (/Users/vsts/agent/2.148.1/work/1/s/node_modules/mocha/lib/runnable.js:379:7)
    at Runner.runTest (/Users/vsts/agent/2.148.1/work/1/s/node_modules/mocha/lib/runner.js:525:10)
    at /Users/vsts/agent/2.148.1/work/1/s/node_modules/mocha/lib/runner.js:643:12
    at next (/Users/vsts/agent/2.148.1/work/1/s/node_modules/mocha/lib/runner.js:437:14)
    at /Users/vsts/agent/2.148.1/work/1/s/node_modules/mocha/lib/runner.js:447:7
    at next (/Users/vsts/agent/2.148.1/work/1/s/node_modules/mocha/lib/runner.js:362:14)
    at Immediate._onImmediate (/Users/vsts/agent/2.148.1/work/1/s/node_modules/mocha/lib/runner.js:415:5)
    at runCallback (timers.js:696:18)
    at tryOnImmediate (timers.js:667:5)
    at processImmediate (timers.js:649:5)
```