### PR TITLE
refactor: Removed fsWatcher from repository

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -46,6 +46,7 @@ import {
   toDisposable
 } from "./util";
 import { match, matchAll } from "./util/globMatch";
+import { RepositoryFilesWatcher } from "./watchers/repositoryFilesWatcher";
 
 function shouldShowProgress(operation: Operation): boolean {
   switch (operation) {
@@ -77,6 +78,11 @@ export class Repository implements IRemoteRepository {
   private deletedUris: Uri[] = [];
 
   private lastPromptAuth?: Thenable<IAuth | undefined>;
+
+  private _fsWatcher: RepositoryFilesWatcher;
+  public get fsWatcher() {
+    return this._fsWatcher;
+  }
 
   private _onDidChangeRepository = new EventEmitter<Uri>();
   public readonly onDidChangeRepository: Event<Uri> = this
@@ -171,32 +177,13 @@ export class Repository implements IRemoteRepository {
   }
 
   constructor(public repository: BaseRepository) {
-    const fsWatcher = workspace.createFileSystemWatcher("**");
-    this.disposables.push(fsWatcher);
+    this._fsWatcher = new RepositoryFilesWatcher(repository.root);
+    this.disposables.push(this._fsWatcher);
 
-    const onWorkspaceChange = anyEvent(
-      fsWatcher.onDidChange,
-      fsWatcher.onDidCreate,
-      fsWatcher.onDidDelete
-    );
-
-    const onRepositoryChange = filterEvent(
-      onWorkspaceChange,
-      uri => !/^\.\./.test(path.relative(repository.root, uri.fsPath))
-    );
-    const onRelevantRepositoryChange = filterEvent(
-      onRepositoryChange,
-      uri => !/[\\\/]\.svn[\\\/]tmp/.test(uri.path)
-    );
-
-    onRelevantRepositoryChange(this.onFSChange, this, this.disposables);
-
-    const onRelevantSvnChange = filterEvent(onRelevantRepositoryChange, uri =>
-      /[\\\/]\.svn[\\\/]/.test(uri.path)
-    );
+    this._fsWatcher.onDidAny(this.onFSChange, this, this.disposables);
 
     // TODO on svn switch event fired two times since two files were changed
-    onRelevantSvnChange(
+    this._fsWatcher.onDidSvnAny(
       async (e: Uri) => {
         await this.repository.updateInfo();
         this._onDidChangeRepository.fire(e);
@@ -263,12 +250,11 @@ export class Repository implements IRemoteRepository {
     );
 
     // For each deleted file, append to list
-    const onFsDelete = filterEvent(
-      fsWatcher.onDidDelete,
-      uri => !/[\\\/]\.svn[\\\/]/.test(uri.path)
+    this._fsWatcher.onDidWorkspaceDelete(
+      uri => this.deletedUris.push(uri),
+      this,
+      this.disposables
     );
-
-    onFsDelete(uri => this.deletedUris.push(uri), this, this.disposables);
 
     // Only check deleted files after the status list is fully updated
     this.onDidChangeStatus(this.actionForDeletedFiles, this, this.disposables);

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -11,7 +11,7 @@ const testRunner = IstanbulTestRunner;
 const mochaOpts: Mocha.MochaOptions = {
   ui: "tdd", // the TDD UI is being used in extension.test.ts (suite, test, etc.)
   useColors: true, // colored output from test results,
-  timeout: 10000, // default timeout: 10 seconds
+  timeout: 30000, // default timeout: 10 seconds
   retries: 1,
   reporter: "mocha-multi-reporters",
   reporterOptions: {

--- a/src/watchers/repositoryFilesWatcher.ts
+++ b/src/watchers/repositoryFilesWatcher.ts
@@ -1,0 +1,70 @@
+import { Event, EventEmitter, Uri, workspace } from "vscode";
+import { anyEvent, filterEvent, IDisposable, isDescendant } from "../util";
+
+export class RepositoryFilesWatcher implements IDisposable {
+  private disposables: IDisposable[] = [];
+
+  public onDidChange: Event<Uri>;
+  public onDidCreate: Event<Uri>;
+  public onDidDelete: Event<Uri>;
+  public onDidAny: Event<Uri>;
+
+  public onDidWorkspaceChange: Event<Uri>;
+  public onDidWorkspaceCreate: Event<Uri>;
+  public onDidWorkspaceDelete: Event<Uri>;
+  public onDidWorkspaceAny: Event<Uri>;
+
+  public onDidSvnChange: Event<Uri>;
+  public onDidSvnCreate: Event<Uri>;
+  public onDidSvnDelete: Event<Uri>;
+  public onDidSvnAny: Event<Uri>;
+
+  constructor(readonly root: string) {
+    const fsWatcher = workspace.createFileSystemWatcher("**");
+    this.disposables.push(fsWatcher);
+
+    const ignoreTmp = (uri: Uri) => !/[\\\/]\.svn[\\\/]tmp/.test(uri.path);
+
+    const ignoreNonRelevants = (uri: Uri) =>
+      ignoreTmp(uri) && !isDescendant(this.root, uri.fsPath);
+
+    this.onDidChange = filterEvent(fsWatcher.onDidChange, ignoreNonRelevants);
+    this.onDidCreate = filterEvent(fsWatcher.onDidCreate, ignoreNonRelevants);
+    this.onDidDelete = filterEvent(fsWatcher.onDidDelete, ignoreNonRelevants);
+
+    this.onDidAny = anyEvent(
+      this.onDidChange,
+      this.onDidCreate,
+      this.onDidDelete
+    );
+
+    const svnPattern = /[\\\/]\.svn[\\\/]/;
+
+    const ignoreSvn = (uri: Uri) => !svnPattern.test(uri.path);
+
+    this.onDidWorkspaceChange = filterEvent(this.onDidChange, ignoreSvn);
+    this.onDidWorkspaceCreate = filterEvent(this.onDidCreate, ignoreSvn);
+    this.onDidWorkspaceDelete = filterEvent(this.onDidDelete, ignoreSvn);
+
+    this.onDidWorkspaceAny = anyEvent(
+      this.onDidWorkspaceChange,
+      this.onDidWorkspaceCreate,
+      this.onDidWorkspaceDelete
+    );
+    const ignoreWorkspace = (uri: Uri) => svnPattern.test(uri.path);
+
+    this.onDidSvnChange = filterEvent(this.onDidChange, ignoreWorkspace);
+    this.onDidSvnCreate = filterEvent(this.onDidCreate, ignoreWorkspace);
+    this.onDidSvnDelete = filterEvent(this.onDidDelete, ignoreWorkspace);
+
+    this.onDidSvnAny = anyEvent(
+      this.onDidSvnChange,
+      this.onDidSvnCreate,
+      this.onDidSvnDelete
+    );
+  }
+
+  public dispose(): void {
+    this.disposables.forEach(d => d.dispose());
+  }
+}


### PR DESCRIPTION
The new class `RepositoryFilesWatcher` filter all files events from workspace
* Ignore events in `.svn/tmp`
* Ignore events outside of root of repository
* Can use events only in workspace, only .svn folder or both