### PR TITLE
fix: Fixed .asar file locking (close #437)

### DIFF
--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as path from "path";
 import {
   commands,

--- a/src/commands/deleteUnversioned.ts
+++ b/src/commands/deleteUnversioned.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "original-fs";
 import { SourceControlResourceState, window } from "vscode";
 import { deleteDirectory } from "../util";
 import { Command } from "./command";

--- a/src/commands/openFile.ts
+++ b/src/commands/openFile.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "original-fs";
 import {
   SourceControlResourceState,
   TextDocumentShowOptions,

--- a/src/fs/exists.ts
+++ b/src/fs/exists.ts
@@ -1,4 +1,4 @@
-import { access } from "fs";
+import { access } from "original-fs";
 
 export function exists(path: string): Promise<boolean> {
   return new Promise((resolve, reject) => {

--- a/src/fs/readdir.ts
+++ b/src/fs/readdir.ts
@@ -1,4 +1,4 @@
-import { readdir as fsReaddir } from "fs";
+import { readdir as fsReaddir } from "original-fs";
 
 export function readdir(path: string): Promise<string[]> {
   return new Promise((resolve, reject) => {

--- a/src/fs/stat.ts
+++ b/src/fs/stat.ts
@@ -1,4 +1,4 @@
-import { stat as fsStat, Stats } from "fs";
+import { stat as fsStat, Stats } from "original-fs";
 
 export function stat(filePath: string): Promise<Stats> {
   return new Promise((resolve, reject) => {

--- a/src/historyView/common.ts
+++ b/src/historyView/common.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as path from "path";
 import {
   commands,

--- a/src/historyView/repoLogProvider.ts
+++ b/src/historyView/repoLogProvider.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as path from "path";
 import {
   commands,

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { Stats } from "fs";
+import { Stats } from "original-fs";
 import * as path from "path";
 import {
   commands,

--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as path from "path";
 import * as tmp from "tmp";
 import { Uri, workspace } from "vscode";

--- a/src/tempFiles.ts
+++ b/src/tempFiles.ts
@@ -1,5 +1,5 @@
-// use import { promises as fs } from "fs"; when nodejs will be updated
-import * as fs from "fs";
+// use import { promises as fs } from "original-fs"; when nodejs will be updated
+import * as fs from "original-fs";
 import * as os from "os";
 import * as path from "path";
 import * as util from "util";

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -10,7 +10,7 @@ import * as assert from "assert";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as path from "path";
 import { commands, Uri } from "vscode";
 import { ISvnResourceGroup } from "../common/types";

--- a/src/test/istanbultestrunner.ts
+++ b/src/test/istanbultestrunner.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 "use strict";
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as glob from "glob";
 import * as istanbul from "istanbul";
 import * as Mocha from "mocha";

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -10,7 +10,7 @@ import * as assert from "assert";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as path from "path";
 import { commands, Uri, window, workspace } from "vscode";
 import { Model } from "../model";

--- a/src/test/testUtil.ts
+++ b/src/test/testUtil.ts
@@ -2,7 +2,7 @@
 
 import * as cp from "child_process";
 import { ChildProcess, SpawnOptions } from "child_process";
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as os from "os";
 import { type } from "os";
 import * as path from "path";

--- a/src/tools/generateConfigSectionForReadme.ts
+++ b/src/tools/generateConfigSectionForReadme.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "original-fs";
 import { join } from "path";
 import { cwd } from "process";
 

--- a/src/treeView/nodes/incomingChangeNode.ts
+++ b/src/treeView/nodes/incomingChangeNode.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as path from "path";
 import { TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
 import { Repository } from "../../repository";

--- a/src/types/original-fs.d.ts
+++ b/src/types/original-fs.d.ts
@@ -1,0 +1,3006 @@
+declare module "original-fs" {
+  import * as stream from "stream";
+  import * as events from "events";
+  import { URL } from "url";
+
+  /**
+   * Valid types for path values in "original-fs".
+   */
+  type PathLike = string | Buffer | URL;
+
+  type BinaryData = Buffer | DataView | NodeJS.TypedArray;
+  class Stats {
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isBlockDevice(): boolean;
+    isCharacterDevice(): boolean;
+    isSymbolicLink(): boolean;
+    isFIFO(): boolean;
+    isSocket(): boolean;
+    dev: number;
+    ino: number;
+    mode: number;
+    nlink: number;
+    uid: number;
+    gid: number;
+    rdev: number;
+    size: number;
+    blksize: number;
+    blocks: number;
+    atimeMs: number;
+    mtimeMs: number;
+    ctimeMs: number;
+    birthtimeMs: number;
+    atime: Date;
+    mtime: Date;
+    ctime: Date;
+    birthtime: Date;
+  }
+
+  class Dirent {
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isBlockDevice(): boolean;
+    isCharacterDevice(): boolean;
+    isSymbolicLink(): boolean;
+    isFIFO(): boolean;
+    isSocket(): boolean;
+    name: string;
+  }
+
+  interface FSWatcher extends events.EventEmitter {
+    close(): void;
+
+    /**
+     * events.EventEmitter
+     *   1. change
+     *   2. error
+     */
+    addListener(event: string, listener: (...args: any[]) => void): this;
+    addListener(
+      event: "change",
+      listener: (eventType: string, filename: string | Buffer) => void
+    ): this;
+    addListener(event: "error", listener: (error: Error) => void): this;
+
+    on(event: string, listener: (...args: any[]) => void): this;
+    on(
+      event: "change",
+      listener: (eventType: string, filename: string | Buffer) => void
+    ): this;
+    on(event: "error", listener: (error: Error) => void): this;
+
+    once(event: string, listener: (...args: any[]) => void): this;
+    once(
+      event: "change",
+      listener: (eventType: string, filename: string | Buffer) => void
+    ): this;
+    once(event: "error", listener: (error: Error) => void): this;
+
+    prependListener(event: string, listener: (...args: any[]) => void): this;
+    prependListener(
+      event: "change",
+      listener: (eventType: string, filename: string | Buffer) => void
+    ): this;
+    prependListener(event: "error", listener: (error: Error) => void): this;
+
+    prependOnceListener(
+      event: string,
+      listener: (...args: any[]) => void
+    ): this;
+    prependOnceListener(
+      event: "change",
+      listener: (eventType: string, filename: string | Buffer) => void
+    ): this;
+    prependOnceListener(event: "error", listener: (error: Error) => void): this;
+  }
+
+  class ReadStream extends stream.Readable {
+    close(): void;
+    bytesRead: number;
+    path: string | Buffer;
+
+    /**
+     * events.EventEmitter
+     *   1. open
+     *   2. close
+     */
+    addListener(event: string, listener: (...args: any[]) => void): this;
+    addListener(event: "open", listener: (fd: number) => void): this;
+    addListener(event: "close", listener: () => void): this;
+
+    on(event: string, listener: (...args: any[]) => void): this;
+    on(event: "open", listener: (fd: number) => void): this;
+    on(event: "close", listener: () => void): this;
+
+    once(event: string, listener: (...args: any[]) => void): this;
+    once(event: "open", listener: (fd: number) => void): this;
+    once(event: "close", listener: () => void): this;
+
+    prependListener(event: string, listener: (...args: any[]) => void): this;
+    prependListener(event: "open", listener: (fd: number) => void): this;
+    prependListener(event: "close", listener: () => void): this;
+
+    prependOnceListener(
+      event: string,
+      listener: (...args: any[]) => void
+    ): this;
+    prependOnceListener(event: "open", listener: (fd: number) => void): this;
+    prependOnceListener(event: "close", listener: () => void): this;
+  }
+
+  class WriteStream extends stream.Writable {
+    close(): void;
+    bytesWritten: number;
+    path: string | Buffer;
+
+    /**
+     * events.EventEmitter
+     *   1. open
+     *   2. close
+     */
+    addListener(event: string, listener: (...args: any[]) => void): this;
+    addListener(event: "open", listener: (fd: number) => void): this;
+    addListener(event: "close", listener: () => void): this;
+
+    on(event: string, listener: (...args: any[]) => void): this;
+    on(event: "open", listener: (fd: number) => void): this;
+    on(event: "close", listener: () => void): this;
+
+    once(event: string, listener: (...args: any[]) => void): this;
+    once(event: "open", listener: (fd: number) => void): this;
+    once(event: "close", listener: () => void): this;
+
+    prependListener(event: string, listener: (...args: any[]) => void): this;
+    prependListener(event: "open", listener: (fd: number) => void): this;
+    prependListener(event: "close", listener: () => void): this;
+
+    prependOnceListener(
+      event: string,
+      listener: (...args: any[]) => void
+    ): this;
+    prependOnceListener(event: "open", listener: (fd: number) => void): this;
+    prependOnceListener(event: "close", listener: () => void): this;
+  }
+
+  /**
+   * Asynchronous rename(2) - Change the name or location of a file or directory.
+   * @param oldPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function rename(
+    oldPath: PathLike,
+    newPath: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace rename {
+    /**
+     * Asynchronous rename(2) - Change the name or location of a file or directory.
+     * @param oldPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     */
+    function __promisify__(oldPath: PathLike, newPath: PathLike): Promise<void>;
+  }
+
+  /**
+   * Synchronous rename(2) - Change the name or location of a file or directory.
+   * @param oldPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function renameSync(oldPath: PathLike, newPath: PathLike): void;
+
+  /**
+   * Asynchronous truncate(2) - Truncate a file to a specified length.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param len If not specified, defaults to `0`.
+   */
+  function truncate(
+    path: PathLike,
+    len: number | undefined | null,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  /**
+   * Asynchronous truncate(2) - Truncate a file to a specified length.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function truncate(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace truncate {
+    /**
+     * Asynchronous truncate(2) - Truncate a file to a specified length.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param len If not specified, defaults to `0`.
+     */
+    function __promisify__(path: PathLike, len?: number | null): Promise<void>;
+  }
+
+  /**
+   * Synchronous truncate(2) - Truncate a file to a specified length.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param len If not specified, defaults to `0`.
+   */
+  function truncateSync(path: PathLike, len?: number | null): void;
+
+  /**
+   * Asynchronous ftruncate(2) - Truncate a file to a specified length.
+   * @param fd A file descriptor.
+   * @param len If not specified, defaults to `0`.
+   */
+  function ftruncate(
+    fd: number,
+    len: number | undefined | null,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  /**
+   * Asynchronous ftruncate(2) - Truncate a file to a specified length.
+   * @param fd A file descriptor.
+   */
+  function ftruncate(
+    fd: number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace ftruncate {
+    /**
+     * Asynchronous ftruncate(2) - Truncate a file to a specified length.
+     * @param fd A file descriptor.
+     * @param len If not specified, defaults to `0`.
+     */
+    function __promisify__(fd: number, len?: number | null): Promise<void>;
+  }
+
+  /**
+   * Synchronous ftruncate(2) - Truncate a file to a specified length.
+   * @param fd A file descriptor.
+   * @param len If not specified, defaults to `0`.
+   */
+  function ftruncateSync(fd: number, len?: number | null): void;
+
+  /**
+   * Asynchronous chown(2) - Change ownership of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function chown(
+    path: PathLike,
+    uid: number,
+    gid: number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace chown {
+    /**
+     * Asynchronous chown(2) - Change ownership of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function __promisify__(
+      path: PathLike,
+      uid: number,
+      gid: number
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronous chown(2) - Change ownership of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function chownSync(path: PathLike, uid: number, gid: number): void;
+
+  /**
+   * Asynchronous fchown(2) - Change ownership of a file.
+   * @param fd A file descriptor.
+   */
+  function fchown(
+    fd: number,
+    uid: number,
+    gid: number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace fchown {
+    /**
+     * Asynchronous fchown(2) - Change ownership of a file.
+     * @param fd A file descriptor.
+     */
+    function __promisify__(fd: number, uid: number, gid: number): Promise<void>;
+  }
+
+  /**
+   * Synchronous fchown(2) - Change ownership of a file.
+   * @param fd A file descriptor.
+   */
+  function fchownSync(fd: number, uid: number, gid: number): void;
+
+  /**
+   * Asynchronous lchown(2) - Change ownership of a file. Does not dereference symbolic links.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function lchown(
+    path: PathLike,
+    uid: number,
+    gid: number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace lchown {
+    /**
+     * Asynchronous lchown(2) - Change ownership of a file. Does not dereference symbolic links.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function __promisify__(
+      path: PathLike,
+      uid: number,
+      gid: number
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronous lchown(2) - Change ownership of a file. Does not dereference symbolic links.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function lchownSync(path: PathLike, uid: number, gid: number): void;
+
+  /**
+   * Asynchronous chmod(2) - Change permissions of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+   */
+  function chmod(
+    path: PathLike,
+    mode: string | number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace chmod {
+    /**
+     * Asynchronous chmod(2) - Change permissions of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+     */
+    function __promisify__(
+      path: PathLike,
+      mode: string | number
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronous chmod(2) - Change permissions of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+   */
+  function chmodSync(path: PathLike, mode: string | number): void;
+
+  /**
+   * Asynchronous fchmod(2) - Change permissions of a file.
+   * @param fd A file descriptor.
+   * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+   */
+  function fchmod(
+    fd: number,
+    mode: string | number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace fchmod {
+    /**
+     * Asynchronous fchmod(2) - Change permissions of a file.
+     * @param fd A file descriptor.
+     * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+     */
+    function __promisify__(fd: number, mode: string | number): Promise<void>;
+  }
+
+  /**
+   * Synchronous fchmod(2) - Change permissions of a file.
+   * @param fd A file descriptor.
+   * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+   */
+  function fchmodSync(fd: number, mode: string | number): void;
+
+  /**
+   * Asynchronous lchmod(2) - Change permissions of a file. Does not dereference symbolic links.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+   */
+  function lchmod(
+    path: PathLike,
+    mode: string | number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace lchmod {
+    /**
+     * Asynchronous lchmod(2) - Change permissions of a file. Does not dereference symbolic links.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+     */
+    function __promisify__(
+      path: PathLike,
+      mode: string | number
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronous lchmod(2) - Change permissions of a file. Does not dereference symbolic links.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+   */
+  function lchmodSync(path: PathLike, mode: string | number): void;
+
+  /**
+   * Asynchronous stat(2) - Get file status.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function stat(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException, stats: Stats) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace stat {
+    /**
+     * Asynchronous stat(2) - Get file status.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function __promisify__(path: PathLike): Promise<Stats>;
+  }
+
+  /**
+   * Synchronous stat(2) - Get file status.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function statSync(path: PathLike): Stats;
+
+  /**
+   * Asynchronous fstat(2) - Get file status.
+   * @param fd A file descriptor.
+   */
+  function fstat(
+    fd: number,
+    callback: (err: NodeJS.ErrnoException, stats: Stats) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace fstat {
+    /**
+     * Asynchronous fstat(2) - Get file status.
+     * @param fd A file descriptor.
+     */
+    function __promisify__(fd: number): Promise<Stats>;
+  }
+
+  /**
+   * Synchronous fstat(2) - Get file status.
+   * @param fd A file descriptor.
+   */
+  function fstatSync(fd: number): Stats;
+
+  /**
+   * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function lstat(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException, stats: Stats) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace lstat {
+    /**
+     * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function __promisify__(path: PathLike): Promise<Stats>;
+  }
+
+  /**
+   * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function lstatSync(path: PathLike): Stats;
+
+  /**
+   * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.
+   * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function link(
+    existingPath: PathLike,
+    newPath: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace link {
+    /**
+     * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.
+     * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
+  }
+
+  /**
+   * Synchronous link(2) - Create a new link (also known as a hard link) to an existing file.
+   * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function linkSync(existingPath: PathLike, newPath: PathLike): void;
+
+  /**
+   * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
+   * @param target A path to an existing file. If a URL is provided, it must use the `file:` protocol.
+   * @param path A path to the new symlink. If a URL is provided, it must use the `file:` protocol.
+   * @param type May be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
+   * When using `'junction'`, the `target` argument will automatically be normalized to an absolute path.
+   */
+  function symlink(
+    target: PathLike,
+    path: PathLike,
+    type: symlink.Type | undefined | null,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  /**
+   * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
+   * @param target A path to an existing file. If a URL is provided, it must use the `file:` protocol.
+   * @param path A path to the new symlink. If a URL is provided, it must use the `file:` protocol.
+   */
+  function symlink(
+    target: PathLike,
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace symlink {
+    /**
+     * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
+     * @param target A path to an existing file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to the new symlink. If a URL is provided, it must use the `file:` protocol.
+     * @param type May be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
+     * When using `'junction'`, the `target` argument will automatically be normalized to an absolute path.
+     */
+    function __promisify__(
+      target: PathLike,
+      path: PathLike,
+      type?: string | null
+    ): Promise<void>;
+
+    type Type = "dir" | "file" | "junction";
+  }
+
+  /**
+   * Synchronous symlink(2) - Create a new symbolic link to an existing file.
+   * @param target A path to an existing file. If a URL is provided, it must use the `file:` protocol.
+   * @param path A path to the new symlink. If a URL is provided, it must use the `file:` protocol.
+   * @param type May be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
+   * When using `'junction'`, the `target` argument will automatically be normalized to an absolute path.
+   */
+  function symlinkSync(
+    target: PathLike,
+    path: PathLike,
+    type?: symlink.Type | null
+  ): void;
+
+  /**
+   * Asynchronous readlink(2) - read value of a symbolic link.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readlink(
+    path: PathLike,
+    options:
+      | { encoding?: BufferEncoding | null }
+      | BufferEncoding
+      | undefined
+      | null,
+    callback: (err: NodeJS.ErrnoException, linkString: string) => void
+  ): void;
+
+  /**
+   * Asynchronous readlink(2) - read value of a symbolic link.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readlink(
+    path: PathLike,
+    options: { encoding: "buffer" } | "buffer",
+    callback: (err: NodeJS.ErrnoException, linkString: Buffer) => void
+  ): void;
+
+  /**
+   * Asynchronous readlink(2) - read value of a symbolic link.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readlink(
+    path: PathLike,
+    options: { encoding?: string | null } | string | undefined | null,
+    callback: (err: NodeJS.ErrnoException, linkString: string | Buffer) => void
+  ): void;
+
+  /**
+   * Asynchronous readlink(2) - read value of a symbolic link.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function readlink(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException, linkString: string) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace readlink {
+    /**
+     * Asynchronous readlink(2) - read value of a symbolic link.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    ): Promise<string>;
+
+    /**
+     * Asynchronous readlink(2) - read value of a symbolic link.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options: { encoding: "buffer" } | "buffer"
+    ): Promise<Buffer>;
+
+    /**
+     * Asynchronous readlink(2) - read value of a symbolic link.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options?: { encoding?: string | null } | string | null
+    ): Promise<string | Buffer>;
+  }
+
+  /**
+   * Synchronous readlink(2) - read value of a symbolic link.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readlinkSync(
+    path: PathLike,
+    options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+  ): string;
+
+  /**
+   * Synchronous readlink(2) - read value of a symbolic link.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readlinkSync(
+    path: PathLike,
+    options: { encoding: "buffer" } | "buffer"
+  ): Buffer;
+
+  /**
+   * Synchronous readlink(2) - read value of a symbolic link.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readlinkSync(
+    path: PathLike,
+    options?: { encoding?: string | null } | string | null
+  ): string | Buffer;
+
+  /**
+   * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function realpath(
+    path: PathLike,
+    options:
+      | { encoding?: BufferEncoding | null }
+      | BufferEncoding
+      | undefined
+      | null,
+    callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void
+  ): void;
+
+  /**
+   * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function realpath(
+    path: PathLike,
+    options: { encoding: "buffer" } | "buffer",
+    callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void
+  ): void;
+
+  /**
+   * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function realpath(
+    path: PathLike,
+    options: { encoding?: string | null } | string | undefined | null,
+    callback: (
+      err: NodeJS.ErrnoException,
+      resolvedPath: string | Buffer
+    ) => void
+  ): void;
+
+  /**
+   * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function realpath(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace realpath {
+    /**
+     * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    ): Promise<string>;
+
+    /**
+     * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options: { encoding: "buffer" } | "buffer"
+    ): Promise<Buffer>;
+
+    /**
+     * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options?: { encoding?: string | null } | string | null
+    ): Promise<string | Buffer>;
+
+    function native(
+      path: PathLike,
+      options:
+        | { encoding?: BufferEncoding | null }
+        | BufferEncoding
+        | undefined
+        | null,
+      callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void
+    ): void;
+    function native(
+      path: PathLike,
+      options: { encoding: "buffer" } | "buffer",
+      callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void
+    ): void;
+    function native(
+      path: PathLike,
+      options: { encoding?: string | null } | string | undefined | null,
+      callback: (
+        err: NodeJS.ErrnoException,
+        resolvedPath: string | Buffer
+      ) => void
+    ): void;
+    function native(
+      path: PathLike,
+      callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void
+    ): void;
+  }
+
+  /**
+   * Synchronous realpath(3) - return the canonicalized absolute pathname.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function realpathSync(
+    path: PathLike,
+    options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+  ): string;
+
+  /**
+   * Synchronous realpath(3) - return the canonicalized absolute pathname.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function realpathSync(
+    path: PathLike,
+    options: { encoding: "buffer" } | "buffer"
+  ): Buffer;
+
+  /**
+   * Synchronous realpath(3) - return the canonicalized absolute pathname.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function realpathSync(
+    path: PathLike,
+    options?: { encoding?: string | null } | string | null
+  ): string | Buffer;
+
+  namespace realpathSync {
+    function native(
+      path: PathLike,
+      options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    ): string;
+    function native(
+      path: PathLike,
+      options: { encoding: "buffer" } | "buffer"
+    ): Buffer;
+    function native(
+      path: PathLike,
+      options?: { encoding?: string | null } | string | null
+    ): string | Buffer;
+  }
+
+  /**
+   * Asynchronous unlink(2) - delete a name and possibly the file it refers to.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function unlink(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace unlink {
+    /**
+     * Asynchronous unlink(2) - delete a name and possibly the file it refers to.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function __promisify__(path: PathLike): Promise<void>;
+  }
+
+  /**
+   * Synchronous unlink(2) - delete a name and possibly the file it refers to.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function unlinkSync(path: PathLike): void;
+
+  /**
+   * Asynchronous rmdir(2) - delete a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function rmdir(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace rmdir {
+    /**
+     * Asynchronous rmdir(2) - delete a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function __promisify__(path: PathLike): Promise<void>;
+  }
+
+  /**
+   * Synchronous rmdir(2) - delete a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function rmdirSync(path: PathLike): void;
+
+  export interface MakeDirectoryOptions {
+    /**
+     * Indicates whether parent folders should be created.
+     * @default false
+     */
+    recursive?: boolean;
+    /**
+     * A file mode. If a string is passed, it is parsed as an octal integer. If not specified
+     * @default 0o777.
+     */
+    mode?: number;
+  }
+
+  /**
+   * Asynchronous mkdir(2) - create a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
+   * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
+   */
+  function mkdir(
+    path: PathLike,
+    options: number | string | MakeDirectoryOptions | undefined | null,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  /**
+   * Asynchronous mkdir(2) - create a directory with a mode of `0o777`.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function mkdir(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace mkdir {
+    /**
+     * Asynchronous mkdir(2) - create a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
+     * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
+     */
+    function __promisify__(
+      path: PathLike,
+      options?: number | string | MakeDirectoryOptions | null
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronous mkdir(2) - create a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
+   * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
+   */
+  function mkdirSync(
+    path: PathLike,
+    options?: number | string | MakeDirectoryOptions | null
+  ): void;
+
+  /**
+   * Asynchronously creates a unique temporary directory.
+   * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function mkdtemp(
+    prefix: string,
+    options:
+      | { encoding?: BufferEncoding | null }
+      | BufferEncoding
+      | undefined
+      | null,
+    callback: (err: NodeJS.ErrnoException, folder: string) => void
+  ): void;
+
+  /**
+   * Asynchronously creates a unique temporary directory.
+   * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function mkdtemp(
+    prefix: string,
+    options: "buffer" | { encoding: "buffer" },
+    callback: (err: NodeJS.ErrnoException, folder: Buffer) => void
+  ): void;
+
+  /**
+   * Asynchronously creates a unique temporary directory.
+   * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function mkdtemp(
+    prefix: string,
+    options: { encoding?: string | null } | string | undefined | null,
+    callback: (err: NodeJS.ErrnoException, folder: string | Buffer) => void
+  ): void;
+
+  /**
+   * Asynchronously creates a unique temporary directory.
+   * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+   */
+  function mkdtemp(
+    prefix: string,
+    callback: (err: NodeJS.ErrnoException, folder: string) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace mkdtemp {
+    /**
+     * Asynchronously creates a unique temporary directory.
+     * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      prefix: string,
+      options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    ): Promise<string>;
+
+    /**
+     * Asynchronously creates a unique temporary directory.
+     * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      prefix: string,
+      options: { encoding: "buffer" } | "buffer"
+    ): Promise<Buffer>;
+
+    /**
+     * Asynchronously creates a unique temporary directory.
+     * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      prefix: string,
+      options?: { encoding?: string | null } | string | null
+    ): Promise<string | Buffer>;
+  }
+
+  /**
+   * Synchronously creates a unique temporary directory.
+   * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function mkdtempSync(
+    prefix: string,
+    options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+  ): string;
+
+  /**
+   * Synchronously creates a unique temporary directory.
+   * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function mkdtempSync(
+    prefix: string,
+    options: { encoding: "buffer" } | "buffer"
+  ): Buffer;
+
+  /**
+   * Synchronously creates a unique temporary directory.
+   * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function mkdtempSync(
+    prefix: string,
+    options?: { encoding?: string | null } | string | null
+  ): string | Buffer;
+
+  /**
+   * Asynchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readdir(
+    path: PathLike,
+    options:
+      | { encoding: BufferEncoding | null; withFileTypes?: false }
+      | BufferEncoding
+      | undefined
+      | null,
+    callback: (err: NodeJS.ErrnoException, files: string[]) => void
+  ): void;
+
+  /**
+   * Asynchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readdir(
+    path: PathLike,
+    options: { encoding: "buffer"; withFileTypes?: false } | "buffer",
+    callback: (err: NodeJS.ErrnoException, files: Buffer[]) => void
+  ): void;
+
+  /**
+   * Asynchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readdir(
+    path: PathLike,
+    options:
+      | { encoding?: string | null; withFileTypes?: false }
+      | string
+      | undefined
+      | null,
+    callback: (err: NodeJS.ErrnoException, files: string[] | Buffer[]) => void
+  ): void;
+
+  /**
+   * Asynchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function readdir(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException, files: string[]) => void
+  ): void;
+
+  /**
+   * Asynchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options If called with `withFileTypes: true` the result data will be an array of Dirent.
+   */
+  function readdir(
+    path: PathLike,
+    options: { withFileTypes: true },
+    callback: (err: NodeJS.ErrnoException, files: Dirent[]) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace readdir {
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options?:
+        | { encoding: BufferEncoding | null; withFileTypes?: false }
+        | BufferEncoding
+        | null
+    ): Promise<string[]>;
+
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options: "buffer" | { encoding: "buffer"; withFileTypes?: false }
+    ): Promise<Buffer[]>;
+
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function __promisify__(
+      path: PathLike,
+      options?:
+        | { encoding?: string | null; withFileTypes?: false }
+        | string
+        | null
+    ): Promise<string[] | Buffer[]>;
+
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options If called with `withFileTypes: true` the result data will be an array of Dirent
+     */
+    function __promisify__(
+      path: PathLike,
+      options: { withFileTypes: true }
+    ): Promise<Dirent[]>;
+  }
+
+  /**
+   * Synchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readdirSync(
+    path: PathLike,
+    options?:
+      | { encoding: BufferEncoding | null; withFileTypes?: false }
+      | BufferEncoding
+      | null
+  ): string[];
+
+  /**
+   * Synchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readdirSync(
+    path: PathLike,
+    options: { encoding: "buffer"; withFileTypes?: false } | "buffer"
+  ): Buffer[];
+
+  /**
+   * Synchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+   */
+  function readdirSync(
+    path: PathLike,
+    options?:
+      | { encoding?: string | null; withFileTypes?: false }
+      | string
+      | null
+  ): string[] | Buffer[];
+
+  /**
+   * Asynchronous readdir(3) - read a directory.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param options If called with `withFileTypes: true` the result data will be an array of Dirent.
+   */
+  function readdirSync(
+    path: PathLike,
+    options: { withFileTypes: true }
+  ): Dirent[];
+
+  /**
+   * Asynchronous close(2) - close a file descriptor.
+   * @param fd A file descriptor.
+   */
+  function close(
+    fd: number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace close {
+    /**
+     * Asynchronous close(2) - close a file descriptor.
+     * @param fd A file descriptor.
+     */
+    function __promisify__(fd: number): Promise<void>;
+  }
+
+  /**
+   * Synchronous close(2) - close a file descriptor.
+   * @param fd A file descriptor.
+   */
+  function closeSync(fd: number): void;
+
+  /**
+   * Asynchronous open(2) - open and possibly create a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
+   */
+  function open(
+    path: PathLike,
+    flags: string | number,
+    mode: string | number | undefined | null,
+    callback: (err: NodeJS.ErrnoException, fd: number) => void
+  ): void;
+
+  /**
+   * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   */
+  function open(
+    path: PathLike,
+    flags: string | number,
+    callback: (err: NodeJS.ErrnoException, fd: number) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace open {
+    /**
+     * Asynchronous open(2) - open and possibly create a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
+     */
+    function __promisify__(
+      path: PathLike,
+      flags: string | number,
+      mode?: string | number | null
+    ): Promise<number>;
+  }
+
+  /**
+   * Synchronous open(2) - open and possibly create a file, returning a file descriptor..
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
+   */
+  function openSync(
+    path: PathLike,
+    flags: string | number,
+    mode?: string | number | null
+  ): number;
+
+  /**
+   * Asynchronously change file timestamps of the file referenced by the supplied path.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param atime The last access time. If a string is provided, it will be coerced to number.
+   * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+   */
+  function utimes(
+    path: PathLike,
+    atime: string | number | Date,
+    mtime: string | number | Date,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace utimes {
+    /**
+     * Asynchronously change file timestamps of the file referenced by the supplied path.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    function __promisify__(
+      path: PathLike,
+      atime: string | number | Date,
+      mtime: string | number | Date
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronously change file timestamps of the file referenced by the supplied path.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * @param atime The last access time. If a string is provided, it will be coerced to number.
+   * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+   */
+  function utimesSync(
+    path: PathLike,
+    atime: string | number | Date,
+    mtime: string | number | Date
+  ): void;
+
+  /**
+   * Asynchronously change file timestamps of the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param atime The last access time. If a string is provided, it will be coerced to number.
+   * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+   */
+  function futimes(
+    fd: number,
+    atime: string | number | Date,
+    mtime: string | number | Date,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace futimes {
+    /**
+     * Asynchronously change file timestamps of the file referenced by the supplied file descriptor.
+     * @param fd A file descriptor.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    function __promisify__(
+      fd: number,
+      atime: string | number | Date,
+      mtime: string | number | Date
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronously change file timestamps of the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param atime The last access time. If a string is provided, it will be coerced to number.
+   * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+   */
+  function futimesSync(
+    fd: number,
+    atime: string | number | Date,
+    mtime: string | number | Date
+  ): void;
+
+  /**
+   * Asynchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
+   * @param fd A file descriptor.
+   */
+  function fsync(
+    fd: number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace fsync {
+    /**
+     * Asynchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
+     * @param fd A file descriptor.
+     */
+    function __promisify__(fd: number): Promise<void>;
+  }
+
+  /**
+   * Synchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
+   * @param fd A file descriptor.
+   */
+  function fsyncSync(fd: number): void;
+
+  /**
+   * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
+   * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+   * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+   */
+  function write<TBuffer extends BinaryData>(
+    fd: number,
+    buffer: TBuffer,
+    offset: number | undefined | null,
+    length: number | undefined | null,
+    position: number | undefined | null,
+    callback: (
+      err: NodeJS.ErrnoException,
+      written: number,
+      buffer: TBuffer
+    ) => void
+  ): void;
+
+  /**
+   * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
+   * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+   */
+  function write<TBuffer extends BinaryData>(
+    fd: number,
+    buffer: TBuffer,
+    offset: number | undefined | null,
+    length: number | undefined | null,
+    callback: (
+      err: NodeJS.ErrnoException,
+      written: number,
+      buffer: TBuffer
+    ) => void
+  ): void;
+
+  /**
+   * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
+   */
+  function write<TBuffer extends BinaryData>(
+    fd: number,
+    buffer: TBuffer,
+    offset: number | undefined | null,
+    callback: (
+      err: NodeJS.ErrnoException,
+      written: number,
+      buffer: TBuffer
+    ) => void
+  ): void;
+
+  /**
+   * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   */
+  function write<TBuffer extends BinaryData>(
+    fd: number,
+    buffer: TBuffer,
+    callback: (
+      err: NodeJS.ErrnoException,
+      written: number,
+      buffer: TBuffer
+    ) => void
+  ): void;
+
+  /**
+   * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
+   * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+   * @param encoding The expected string encoding.
+   */
+  function write(
+    fd: number,
+    string: any,
+    position: number | undefined | null,
+    encoding: string | undefined | null,
+    callback: (err: NodeJS.ErrnoException, written: number, str: string) => void
+  ): void;
+
+  /**
+   * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
+   * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+   */
+  function write(
+    fd: number,
+    string: any,
+    position: number | undefined | null,
+    callback: (err: NodeJS.ErrnoException, written: number, str: string) => void
+  ): void;
+
+  /**
+   * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
+   */
+  function write(
+    fd: number,
+    string: any,
+    callback: (err: NodeJS.ErrnoException, written: number, str: string) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace write {
+    /**
+     * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+     * @param fd A file descriptor.
+     * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
+     * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+     * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+     */
+    function __promisify__<TBuffer extends BinaryData>(
+      fd: number,
+      buffer?: TBuffer,
+      offset?: number,
+      length?: number,
+      position?: number | null
+    ): Promise<{ bytesWritten: number; buffer: TBuffer }>;
+
+    /**
+     * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
+     * @param fd A file descriptor.
+     * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
+     * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+     * @param encoding The expected string encoding.
+     */
+    function __promisify__(
+      fd: number,
+      string: any,
+      position?: number | null,
+      encoding?: string | null
+    ): Promise<{ bytesWritten: number; buffer: string }>;
+  }
+
+  /**
+   * Synchronously writes `buffer` to the file referenced by the supplied file descriptor, returning the number of bytes written.
+   * @param fd A file descriptor.
+   * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
+   * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+   * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+   */
+  function writeSync(
+    fd: number,
+    buffer: BinaryData,
+    offset?: number | null,
+    length?: number | null,
+    position?: number | null
+  ): number;
+
+  /**
+   * Synchronously writes `string` to the file referenced by the supplied file descriptor, returning the number of bytes written.
+   * @param fd A file descriptor.
+   * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
+   * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+   * @param encoding The expected string encoding.
+   */
+  function writeSync(
+    fd: number,
+    string: any,
+    position?: number | null,
+    encoding?: string | null
+  ): number;
+
+  /**
+   * Asynchronously reads data from the file referenced by the supplied file descriptor.
+   * @param fd A file descriptor.
+   * @param buffer The buffer that the data will be written to.
+   * @param offset The offset in the buffer at which to start writing.
+   * @param length The number of bytes to read.
+   * @param position The offset from the beginning of the file from which data should be read. If `null`, data will be read from the current position.
+   */
+  function read<TBuffer extends BinaryData>(
+    fd: number,
+    buffer: TBuffer,
+    offset: number,
+    length: number,
+    position: number | null,
+    callback: (
+      err: NodeJS.ErrnoException,
+      bytesRead: number,
+      buffer: TBuffer
+    ) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace read {
+    /**
+     * @param fd A file descriptor.
+     * @param buffer The buffer that the data will be written to.
+     * @param offset The offset in the buffer at which to start writing.
+     * @param length The number of bytes to read.
+     * @param position The offset from the beginning of the file from which data should be read. If `null`, data will be read from the current position.
+     */
+    function __promisify__<TBuffer extends BinaryData>(
+      fd: number,
+      buffer: TBuffer,
+      offset: number,
+      length: number,
+      position: number | null
+    ): Promise<{ bytesRead: number; buffer: TBuffer }>;
+  }
+
+  /**
+   * Synchronously reads data from the file referenced by the supplied file descriptor, returning the number of bytes read.
+   * @param fd A file descriptor.
+   * @param buffer The buffer that the data will be written to.
+   * @param offset The offset in the buffer at which to start writing.
+   * @param length The number of bytes to read.
+   * @param position The offset from the beginning of the file from which data should be read. If `null`, data will be read from the current position.
+   */
+  function readSync(
+    fd: number,
+    buffer: BinaryData,
+    offset: number,
+    length: number,
+    position: number | null
+  ): number;
+
+  /**
+   * Asynchronously reads the entire contents of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param options An object that may contain an optional flag.
+   * If a flag is not provided, it defaults to `'r'`.
+   */
+  function readFile(
+    path: PathLike | number,
+    options: { encoding?: null; flag?: string } | undefined | null,
+    callback: (err: NodeJS.ErrnoException, data: Buffer) => void
+  ): void;
+
+  /**
+   * Asynchronously reads the entire contents of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
+   * If a flag is not provided, it defaults to `'r'`.
+   */
+  function readFile(
+    path: PathLike | number,
+    options: { encoding: string; flag?: string } | string,
+    callback: (err: NodeJS.ErrnoException, data: string) => void
+  ): void;
+
+  /**
+   * Asynchronously reads the entire contents of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
+   * If a flag is not provided, it defaults to `'r'`.
+   */
+  function readFile(
+    path: PathLike | number,
+    options:
+      | { encoding?: string | null; flag?: string }
+      | string
+      | undefined
+      | null,
+    callback: (err: NodeJS.ErrnoException, data: string | Buffer) => void
+  ): void;
+
+  /**
+   * Asynchronously reads the entire contents of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   */
+  function readFile(
+    path: PathLike | number,
+    callback: (err: NodeJS.ErrnoException, data: Buffer) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace readFile {
+    /**
+     * Asynchronously reads the entire contents of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+     * @param options An object that may contain an optional flag.
+     * If a flag is not provided, it defaults to `'r'`.
+     */
+    function __promisify__(
+      path: PathLike | number,
+      options?: { encoding?: null; flag?: string } | null
+    ): Promise<Buffer>;
+
+    /**
+     * Asynchronously reads the entire contents of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
+     * If a flag is not provided, it defaults to `'r'`.
+     */
+    function __promisify__(
+      path: PathLike | number,
+      options: { encoding: string; flag?: string } | string
+    ): Promise<string>;
+
+    /**
+     * Asynchronously reads the entire contents of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+     * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
+     * If a flag is not provided, it defaults to `'r'`.
+     */
+    function __promisify__(
+      path: PathLike | number,
+      options?: { encoding?: string | null; flag?: string } | string | null
+    ): Promise<string | Buffer>;
+  }
+
+  /**
+   * Synchronously reads the entire contents of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param options An object that may contain an optional flag. If a flag is not provided, it defaults to `'r'`.
+   */
+  function readFileSync(
+    path: PathLike | number,
+    options?: { encoding?: null; flag?: string } | null
+  ): Buffer;
+
+  /**
+   * Synchronously reads the entire contents of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
+   * If a flag is not provided, it defaults to `'r'`.
+   */
+  function readFileSync(
+    path: PathLike | number,
+    options: { encoding: string; flag?: string } | string
+  ): string;
+
+  /**
+   * Synchronously reads the entire contents of a file.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
+   * If a flag is not provided, it defaults to `'r'`.
+   */
+  function readFileSync(
+    path: PathLike | number,
+    options?: { encoding?: string | null; flag?: string } | string | null
+  ): string | Buffer;
+
+  type WriteFileOptions =
+    | { encoding?: string | null; mode?: number | string; flag?: string }
+    | string
+    | null;
+
+  /**
+   * Asynchronously writes data to a file, replacing the file if it already exists.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
+   * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+   * If `encoding` is not supplied, the default of `'utf8'` is used.
+   * If `mode` is not supplied, the default of `0o666` is used.
+   * If `mode` is a string, it is parsed as an octal integer.
+   * If `flag` is not supplied, the default of `'w'` is used.
+   */
+  function writeFile(
+    path: PathLike | number,
+    data: any,
+    options: WriteFileOptions,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  /**
+   * Asynchronously writes data to a file, replacing the file if it already exists.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
+   */
+  function writeFile(
+    path: PathLike | number,
+    data: any,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace writeFile {
+    /**
+     * Asynchronously writes data to a file, replacing the file if it already exists.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+     * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
+     * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+     * If `encoding` is not supplied, the default of `'utf8'` is used.
+     * If `mode` is not supplied, the default of `0o666` is used.
+     * If `mode` is a string, it is parsed as an octal integer.
+     * If `flag` is not supplied, the default of `'w'` is used.
+     */
+    function __promisify__(
+      path: PathLike | number,
+      data: any,
+      options?: WriteFileOptions
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronously writes data to a file, replacing the file if it already exists.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
+   * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+   * If `encoding` is not supplied, the default of `'utf8'` is used.
+   * If `mode` is not supplied, the default of `0o666` is used.
+   * If `mode` is a string, it is parsed as an octal integer.
+   * If `flag` is not supplied, the default of `'w'` is used.
+   */
+  function writeFileSync(
+    path: PathLike | number,
+    data: any,
+    options?: WriteFileOptions
+  ): void;
+
+  /**
+   * Asynchronously append data to a file, creating the file if it does not exist.
+   * @param file A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
+   * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+   * If `encoding` is not supplied, the default of `'utf8'` is used.
+   * If `mode` is not supplied, the default of `0o666` is used.
+   * If `mode` is a string, it is parsed as an octal integer.
+   * If `flag` is not supplied, the default of `'a'` is used.
+   */
+  function appendFile(
+    file: PathLike | number,
+    data: any,
+    options: WriteFileOptions,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  /**
+   * Asynchronously append data to a file, creating the file if it does not exist.
+   * @param file A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
+   */
+  function appendFile(
+    file: PathLike | number,
+    data: any,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace appendFile {
+    /**
+     * Asynchronously append data to a file, creating the file if it does not exist.
+     * @param file A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+     * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
+     * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+     * If `encoding` is not supplied, the default of `'utf8'` is used.
+     * If `mode` is not supplied, the default of `0o666` is used.
+     * If `mode` is a string, it is parsed as an octal integer.
+     * If `flag` is not supplied, the default of `'a'` is used.
+     */
+    function __promisify__(
+      file: PathLike | number,
+      data: any,
+      options?: WriteFileOptions
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronously append data to a file, creating the file if it does not exist.
+   * @param file A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+   * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
+   * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+   * If `encoding` is not supplied, the default of `'utf8'` is used.
+   * If `mode` is not supplied, the default of `0o666` is used.
+   * If `mode` is a string, it is parsed as an octal integer.
+   * If `flag` is not supplied, the default of `'a'` is used.
+   */
+  function appendFileSync(
+    file: PathLike | number,
+    data: any,
+    options?: WriteFileOptions
+  ): void;
+
+  /**
+   * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
+   */
+  function watchFile(
+    filename: PathLike,
+    options: { persistent?: boolean; interval?: number } | undefined,
+    listener: (curr: Stats, prev: Stats) => void
+  ): void;
+
+  /**
+   * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
+   * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function watchFile(
+    filename: PathLike,
+    listener: (curr: Stats, prev: Stats) => void
+  ): void;
+
+  /**
+   * Stop watching for changes on `filename`.
+   * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function unwatchFile(
+    filename: PathLike,
+    listener?: (curr: Stats, prev: Stats) => void
+  ): void;
+
+  /**
+   * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
+   * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
+   * If `encoding` is not supplied, the default of `'utf8'` is used.
+   * If `persistent` is not supplied, the default of `true` is used.
+   * If `recursive` is not supplied, the default of `false` is used.
+   */
+  function watch(
+    filename: PathLike,
+    options:
+      | {
+          encoding?: BufferEncoding | null;
+          persistent?: boolean;
+          recursive?: boolean;
+        }
+      | BufferEncoding
+      | undefined
+      | null,
+    listener?: (event: string, filename: string) => void
+  ): FSWatcher;
+
+  /**
+   * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
+   * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
+   * If `encoding` is not supplied, the default of `'utf8'` is used.
+   * If `persistent` is not supplied, the default of `true` is used.
+   * If `recursive` is not supplied, the default of `false` is used.
+   */
+  function watch(
+    filename: PathLike,
+    options:
+      | { encoding: "buffer"; persistent?: boolean; recursive?: boolean }
+      | "buffer",
+    listener?: (event: string, filename: Buffer) => void
+  ): FSWatcher;
+
+  /**
+   * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
+   * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
+   * If `encoding` is not supplied, the default of `'utf8'` is used.
+   * If `persistent` is not supplied, the default of `true` is used.
+   * If `recursive` is not supplied, the default of `false` is used.
+   */
+  function watch(
+    filename: PathLike,
+    options:
+      | { encoding?: string | null; persistent?: boolean; recursive?: boolean }
+      | string
+      | null,
+    listener?: (event: string, filename: string | Buffer) => void
+  ): FSWatcher;
+
+  /**
+   * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
+   * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function watch(
+    filename: PathLike,
+    listener?: (event: string, filename: string) => any
+  ): FSWatcher;
+
+  /**
+   * Asynchronously tests whether or not the given path exists by checking with the file system.
+   * @deprecated
+   * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function exists(path: PathLike, callback: (exists: boolean) => void): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace exists {
+    /**
+     * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     */
+    function __promisify__(path: PathLike): Promise<boolean>;
+  }
+
+  /**
+   * Synchronously tests whether or not the given path exists by checking with the file system.
+   * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function existsSync(path: PathLike): boolean;
+
+  namespace constants {
+    // File Access Constants
+
+    /** Constant for fs.access(). File is visible to the calling process. */
+    const F_OK: number;
+
+    /** Constant for fs.access(). File can be read by the calling process. */
+    const R_OK: number;
+
+    /** Constant for fs.access(). File can be written by the calling process. */
+    const W_OK: number;
+
+    /** Constant for fs.access(). File can be executed by the calling process. */
+    const X_OK: number;
+
+    // File Copy Constants
+
+    /** Constant for fs.copyFile. Flag indicating the destination file should not be overwritten if it already exists. */
+    const COPYFILE_EXCL: number;
+
+    /**
+     * Constant for fs.copyFile. copy operation will attempt to create a copy-on-write reflink.
+     * If the underlying platform does not support copy-on-write, then a fallback copy mechanism is used.
+     */
+    const COPYFILE_FICLONE: number;
+
+    /**
+     * Constant for fs.copyFile. Copy operation will attempt to create a copy-on-write reflink.
+     * If the underlying platform does not support copy-on-write, then the operation will fail with an error.
+     */
+    const COPYFILE_FICLONE_FORCE: number;
+
+    // File Open Constants
+
+    /** Constant for fs.open(). Flag indicating to open a file for read-only access. */
+    const O_RDONLY: number;
+
+    /** Constant for fs.open(). Flag indicating to open a file for write-only access. */
+    const O_WRONLY: number;
+
+    /** Constant for fs.open(). Flag indicating to open a file for read-write access. */
+    const O_RDWR: number;
+
+    /** Constant for fs.open(). Flag indicating to create the file if it does not already exist. */
+    const O_CREAT: number;
+
+    /** Constant for fs.open(). Flag indicating that opening a file should fail if the O_CREAT flag is set and the file already exists. */
+    const O_EXCL: number;
+
+    /**
+     * Constant for fs.open(). Flag indicating that if path identifies a terminal device,
+     * opening the path shall not cause that terminal to become the controlling terminal for the process
+     * (if the process does not already have one).
+     */
+    const O_NOCTTY: number;
+
+    /** Constant for fs.open(). Flag indicating that if the file exists and is a regular file, and the file is opened successfully for write access, its length shall be truncated to zero. */
+    const O_TRUNC: number;
+
+    /** Constant for fs.open(). Flag indicating that data will be appended to the end of the file. */
+    const O_APPEND: number;
+
+    /** Constant for fs.open(). Flag indicating that the open should fail if the path is not a directory. */
+    const O_DIRECTORY: number;
+
+    /**
+     * constant for fs.open().
+     * Flag indicating reading accesses to the file system will no longer result in
+     * an update to the atime information associated with the file.
+     * This flag is available on Linux operating systems only.
+     */
+    const O_NOATIME: number;
+
+    /** Constant for fs.open(). Flag indicating that the open should fail if the path is a symbolic link. */
+    const O_NOFOLLOW: number;
+
+    /** Constant for fs.open(). Flag indicating that the file is opened for synchronous I/O. */
+    const O_SYNC: number;
+
+    /** Constant for fs.open(). Flag indicating that the file is opened for synchronous I/O with write operations waiting for data integrity. */
+    const O_DSYNC: number;
+
+    /** Constant for fs.open(). Flag indicating to open the symbolic link itself rather than the resource it is pointing to. */
+    const O_SYMLINK: number;
+
+    /** Constant for fs.open(). When set, an attempt will be made to minimize caching effects of file I/O. */
+    const O_DIRECT: number;
+
+    /** Constant for fs.open(). Flag indicating to open the file in nonblocking mode when possible. */
+    const O_NONBLOCK: number;
+
+    // File Type Constants
+
+    /** Constant for fs.Stats mode property for determining a file's type. Bit mask used to extract the file type code. */
+    const S_IFMT: number;
+
+    /** Constant for fs.Stats mode property for determining a file's type. File type constant for a regular file. */
+    const S_IFREG: number;
+
+    /** Constant for fs.Stats mode property for determining a file's type. File type constant for a directory. */
+    const S_IFDIR: number;
+
+    /** Constant for fs.Stats mode property for determining a file's type. File type constant for a character-oriented device file. */
+    const S_IFCHR: number;
+
+    /** Constant for fs.Stats mode property for determining a file's type. File type constant for a block-oriented device file. */
+    const S_IFBLK: number;
+
+    /** Constant for fs.Stats mode property for determining a file's type. File type constant for a FIFO/pipe. */
+    const S_IFIFO: number;
+
+    /** Constant for fs.Stats mode property for determining a file's type. File type constant for a symbolic link. */
+    const S_IFLNK: number;
+
+    /** Constant for fs.Stats mode property for determining a file's type. File type constant for a socket. */
+    const S_IFSOCK: number;
+
+    // File Mode Constants
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable, writable and executable by owner. */
+    const S_IRWXU: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable by owner. */
+    const S_IRUSR: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating writable by owner. */
+    const S_IWUSR: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating executable by owner. */
+    const S_IXUSR: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable, writable and executable by group. */
+    const S_IRWXG: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable by group. */
+    const S_IRGRP: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating writable by group. */
+    const S_IWGRP: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating executable by group. */
+    const S_IXGRP: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable, writable and executable by others. */
+    const S_IRWXO: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable by others. */
+    const S_IROTH: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating writable by others. */
+    const S_IWOTH: number;
+
+    /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating executable by others. */
+    const S_IXOTH: number;
+  }
+
+  /**
+   * Asynchronously tests a user's permissions for the file specified by path.
+   * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function access(
+    path: PathLike,
+    mode: number | undefined,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  /**
+   * Asynchronously tests a user's permissions for the file specified by path.
+   * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function access(
+    path: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace access {
+    /**
+     * Asynchronously tests a user's permissions for the file specified by path.
+     * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     */
+    function __promisify__(path: PathLike, mode?: number): Promise<void>;
+  }
+
+  /**
+   * Synchronously tests a user's permissions for the file specified by path.
+   * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function accessSync(path: PathLike, mode?: number): void;
+
+  /**
+   * Returns a new `ReadStream` object.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function createReadStream(
+    path: PathLike,
+    options?:
+      | string
+      | {
+          flags?: string;
+          encoding?: string;
+          fd?: number;
+          mode?: number;
+          autoClose?: boolean;
+          start?: number;
+          end?: number;
+          highWaterMark?: number;
+        }
+  ): ReadStream;
+
+  /**
+   * Returns a new `WriteStream` object.
+   * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+   * URL support is _experimental_.
+   */
+  function createWriteStream(
+    path: PathLike,
+    options?:
+      | string
+      | {
+          flags?: string;
+          encoding?: string;
+          fd?: number;
+          mode?: number;
+          autoClose?: boolean;
+          start?: number;
+        }
+  ): WriteStream;
+
+  /**
+   * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.
+   * @param fd A file descriptor.
+   */
+  function fdatasync(
+    fd: number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace fdatasync {
+    /**
+     * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.
+     * @param fd A file descriptor.
+     */
+    function __promisify__(fd: number): Promise<void>;
+  }
+
+  /**
+   * Synchronous fdatasync(2) - synchronize a file's in-core state with storage device.
+   * @param fd A file descriptor.
+   */
+  function fdatasyncSync(fd: number): void;
+
+  /**
+   * Asynchronously copies src to dest. By default, dest is overwritten if it already exists.
+   * No arguments other than a possible exception are given to the callback function.
+   * Node.js makes no guarantees about the atomicity of the copy operation.
+   * If an error occurs after the destination file has been opened for writing, Node.js will attempt
+   * to remove the destination.
+   * @param src A path to the source file.
+   * @param dest A path to the destination file.
+   */
+  function copyFile(
+    src: PathLike,
+    dest: PathLike,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+  /**
+   * Asynchronously copies src to dest. By default, dest is overwritten if it already exists.
+   * No arguments other than a possible exception are given to the callback function.
+   * Node.js makes no guarantees about the atomicity of the copy operation.
+   * If an error occurs after the destination file has been opened for writing, Node.js will attempt
+   * to remove the destination.
+   * @param src A path to the source file.
+   * @param dest A path to the destination file.
+   * @param flags An integer that specifies the behavior of the copy operation. The only supported flag is fs.constants.COPYFILE_EXCL, which causes the copy operation to fail if dest already exists.
+   */
+  function copyFile(
+    src: PathLike,
+    dest: PathLike,
+    flags: number,
+    callback: (err: NodeJS.ErrnoException) => void
+  ): void;
+
+  // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
+  namespace copyFile {
+    /**
+     * Asynchronously copies src to dest. By default, dest is overwritten if it already exists.
+     * No arguments other than a possible exception are given to the callback function.
+     * Node.js makes no guarantees about the atomicity of the copy operation.
+     * If an error occurs after the destination file has been opened for writing, Node.js will attempt
+     * to remove the destination.
+     * @param src A path to the source file.
+     * @param dest A path to the destination file.
+     * @param flags An optional integer that specifies the behavior of the copy operation.
+     * The only supported flag is fs.constants.COPYFILE_EXCL,
+     * which causes the copy operation to fail if dest already exists.
+     */
+    function __promisify__(
+      src: PathLike,
+      dst: PathLike,
+      flags?: number
+    ): Promise<void>;
+  }
+
+  /**
+   * Synchronously copies src to dest. By default, dest is overwritten if it already exists.
+   * Node.js makes no guarantees about the atomicity of the copy operation.
+   * If an error occurs after the destination file has been opened for writing, Node.js will attempt
+   * to remove the destination.
+   * @param src A path to the source file.
+   * @param dest A path to the destination file.
+   * @param flags An optional integer that specifies the behavior of the copy operation.
+   * The only supported flag is fs.constants.COPYFILE_EXCL, which causes the copy operation to fail if dest already exists.
+   */
+  function copyFileSync(src: PathLike, dest: PathLike, flags?: number): void;
+
+  namespace promises {
+    interface FileHandle {
+      /**
+       * Gets the file descriptor for this file handle.
+       */
+      readonly fd: number;
+
+      /**
+       * Asynchronously append data to a file, creating the file if it does not exist. The underlying file will _not_ be closed automatically.
+       * The `FileHandle` must have been opened for appending.
+       * @param data The data to write. If something other than a `Buffer` or `Uint8Array` is provided, the value is coerced to a string.
+       * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+       * If `encoding` is not supplied, the default of `'utf8'` is used.
+       * If `mode` is not supplied, the default of `0o666` is used.
+       * If `mode` is a string, it is parsed as an octal integer.
+       * If `flag` is not supplied, the default of `'a'` is used.
+       */
+      appendFile(
+        data: any,
+        options?:
+          | {
+              encoding?: string | null;
+              mode?: string | number;
+              flag?: string | number;
+            }
+          | string
+          | null
+      ): Promise<void>;
+
+      /**
+       * Asynchronous fchown(2) - Change ownership of a file.
+       */
+      chown(uid: number, gid: number): Promise<void>;
+
+      /**
+       * Asynchronous fchmod(2) - Change permissions of a file.
+       * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+       */
+      chmod(mode: string | number): Promise<void>;
+
+      /**
+       * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.
+       */
+      datasync(): Promise<void>;
+
+      /**
+       * Asynchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
+       */
+      sync(): Promise<void>;
+
+      /**
+       * Asynchronously reads data from the file.
+       * The `FileHandle` must have been opened for reading.
+       * @param buffer The buffer that the data will be written to.
+       * @param offset The offset in the buffer at which to start writing.
+       * @param length The number of bytes to read.
+       * @param position The offset from the beginning of the file from which data should be read. If `null`, data will be read from the current position.
+       */
+      read<TBuffer extends Buffer | Uint8Array>(
+        buffer: TBuffer,
+        offset?: number | null,
+        length?: number | null,
+        position?: number | null
+      ): Promise<{ bytesRead: number; buffer: TBuffer }>;
+
+      /**
+       * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
+       * The `FileHandle` must have been opened for reading.
+       * @param options An object that may contain an optional flag.
+       * If a flag is not provided, it defaults to `'r'`.
+       */
+      readFile(
+        options?: { encoding?: null; flag?: string | number } | null
+      ): Promise<Buffer>;
+
+      /**
+       * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
+       * The `FileHandle` must have been opened for reading.
+       * @param options An object that may contain an optional flag.
+       * If a flag is not provided, it defaults to `'r'`.
+       */
+      readFile(
+        options:
+          | { encoding: BufferEncoding; flag?: string | number }
+          | BufferEncoding
+      ): Promise<string>;
+
+      /**
+       * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
+       * The `FileHandle` must have been opened for reading.
+       * @param options An object that may contain an optional flag.
+       * If a flag is not provided, it defaults to `'r'`.
+       */
+      readFile(
+        options?:
+          | { encoding?: string | null; flag?: string | number }
+          | string
+          | null
+      ): Promise<string | Buffer>;
+
+      /**
+       * Asynchronous fstat(2) - Get file status.
+       */
+      stat(): Promise<Stats>;
+
+      /**
+       * Asynchronous ftruncate(2) - Truncate a file to a specified length.
+       * @param len If not specified, defaults to `0`.
+       */
+      truncate(len?: number): Promise<void>;
+
+      /**
+       * Asynchronously change file timestamps of the file.
+       * @param atime The last access time. If a string is provided, it will be coerced to number.
+       * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+       */
+      utimes(
+        atime: string | number | Date,
+        mtime: string | number | Date
+      ): Promise<void>;
+
+      /**
+       * Asynchronously writes `buffer` to the file.
+       * The `FileHandle` must have been opened for writing.
+       * @param buffer The buffer that the data will be written to.
+       * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
+       * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+       * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+       */
+      write<TBuffer extends Buffer | Uint8Array>(
+        buffer: TBuffer,
+        offset?: number | null,
+        length?: number | null,
+        position?: number | null
+      ): Promise<{ bytesWritten: number; buffer: TBuffer }>;
+
+      /**
+       * Asynchronously writes `string` to the file.
+       * The `FileHandle` must have been opened for writing.
+       * It is unsafe to call `write()` multiple times on the same file without waiting for the `Promise`
+       * to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
+       * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
+       * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+       * @param encoding The expected string encoding.
+       */
+      write(
+        data: any,
+        position?: number | null,
+        encoding?: string | null
+      ): Promise<{ bytesWritten: number; buffer: string }>;
+
+      /**
+       * Asynchronously writes data to a file, replacing the file if it already exists. The underlying file will _not_ be closed automatically.
+       * The `FileHandle` must have been opened for writing.
+       * It is unsafe to call `writeFile()` multiple times on the same file without waiting for the `Promise` to be resolved (or rejected).
+       * @param data The data to write. If something other than a `Buffer` or `Uint8Array` is provided, the value is coerced to a string.
+       * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+       * If `encoding` is not supplied, the default of `'utf8'` is used.
+       * If `mode` is not supplied, the default of `0o666` is used.
+       * If `mode` is a string, it is parsed as an octal integer.
+       * If `flag` is not supplied, the default of `'w'` is used.
+       */
+      writeFile(
+        data: any,
+        options?:
+          | {
+              encoding?: string | null;
+              mode?: string | number;
+              flag?: string | number;
+            }
+          | string
+          | null
+      ): Promise<void>;
+
+      /**
+       * Asynchronous close(2) - close a `FileHandle`.
+       */
+      close(): Promise<void>;
+    }
+
+    /**
+     * Asynchronously tests a user's permissions for the file specified by path.
+     * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     */
+    function access(path: PathLike, mode?: number): Promise<void>;
+
+    /**
+     * Asynchronously copies `src` to `dest`. By default, `dest` is overwritten if it already exists.
+     * Node.js makes no guarantees about the atomicity of the copy operation.
+     * If an error occurs after the destination file has been opened for writing, Node.js will attempt
+     * to remove the destination.
+     * @param src A path to the source file.
+     * @param dest A path to the destination file.
+     * @param flags An optional integer that specifies the behavior of the copy operation. The only
+     * supported flag is `fs.constants.COPYFILE_EXCL`, which causes the copy operation to fail if
+     * `dest` already exists.
+     */
+    function copyFile(
+      src: PathLike,
+      dest: PathLike,
+      flags?: number
+    ): Promise<void>;
+
+    /**
+     * Asynchronous open(2) - open and possibly create a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not
+     * supplied, defaults to `0o666`.
+     */
+    function open(
+      path: PathLike,
+      flags: string | number,
+      mode?: string | number
+    ): Promise<FileHandle>;
+
+    /**
+     * Asynchronously reads data from the file referenced by the supplied `FileHandle`.
+     * @param handle A `FileHandle`.
+     * @param buffer The buffer that the data will be written to.
+     * @param offset The offset in the buffer at which to start writing.
+     * @param length The number of bytes to read.
+     * @param position The offset from the beginning of the file from which data should be read. If
+     * `null`, data will be read from the current position.
+     */
+    function read<TBuffer extends Buffer | Uint8Array>(
+      handle: FileHandle,
+      buffer: TBuffer,
+      offset?: number | null,
+      length?: number | null,
+      position?: number | null
+    ): Promise<{ bytesRead: number; buffer: TBuffer }>;
+
+    /**
+     * Asynchronously writes `buffer` to the file referenced by the supplied `FileHandle`.
+     * It is unsafe to call `fsPromises.write()` multiple times on the same file without waiting for the `Promise`
+     * to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
+     * @param handle A `FileHandle`.
+     * @param buffer The buffer that the data will be written to.
+     * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
+     * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+     * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+     */
+    function write<TBuffer extends Buffer | Uint8Array>(
+      handle: FileHandle,
+      buffer: TBuffer,
+      offset?: number | null,
+      length?: number | null,
+      position?: number | null
+    ): Promise<{ bytesWritten: number; buffer: TBuffer }>;
+
+    /**
+     * Asynchronously writes `string` to the file referenced by the supplied `FileHandle`.
+     * It is unsafe to call `fsPromises.write()` multiple times on the same file without waiting for the `Promise`
+     * to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
+     * @param handle A `FileHandle`.
+     * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
+     * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+     * @param encoding The expected string encoding.
+     */
+    function write(
+      handle: FileHandle,
+      string: any,
+      position?: number | null,
+      encoding?: string | null
+    ): Promise<{ bytesWritten: number; buffer: string }>;
+
+    /**
+     * Asynchronous rename(2) - Change the name or location of a file or directory.
+     * @param oldPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     */
+    function rename(oldPath: PathLike, newPath: PathLike): Promise<void>;
+
+    /**
+     * Asynchronous truncate(2) - Truncate a file to a specified length.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param len If not specified, defaults to `0`.
+     */
+    function truncate(path: PathLike, len?: number): Promise<void>;
+
+    /**
+     * Asynchronous ftruncate(2) - Truncate a file to a specified length.
+     * @param handle A `FileHandle`.
+     * @param len If not specified, defaults to `0`.
+     */
+    function ftruncate(handle: FileHandle, len?: number): Promise<void>;
+
+    /**
+     * Asynchronous rmdir(2) - delete a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function rmdir(path: PathLike): Promise<void>;
+
+    /**
+     * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.
+     * @param handle A `FileHandle`.
+     */
+    function fdatasync(handle: FileHandle): Promise<void>;
+
+    /**
+     * Asynchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
+     * @param handle A `FileHandle`.
+     */
+    function fsync(handle: FileHandle): Promise<void>;
+
+    /**
+     * Asynchronous mkdir(2) - create a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options Either the file mode, or an object optionally specifying the file mode and whether parent folders
+     * should be created. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
+     */
+    function mkdir(
+      path: PathLike,
+      options?: number | string | MakeDirectoryOptions | null
+    ): Promise<void>;
+
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function readdir(
+      path: PathLike,
+      options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    ): Promise<string[]>;
+
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function readdir(
+      path: PathLike,
+      options: { encoding: "buffer" } | "buffer"
+    ): Promise<Buffer[]>;
+
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function readdir(
+      path: PathLike,
+      options?: { encoding?: string | null } | string | null
+    ): Promise<string[] | Buffer[]>;
+
+    /**
+     * Asynchronous readlink(2) - read value of a symbolic link.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function readlink(
+      path: PathLike,
+      options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    ): Promise<string>;
+
+    /**
+     * Asynchronous readlink(2) - read value of a symbolic link.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function readlink(
+      path: PathLike,
+      options: { encoding: "buffer" } | "buffer"
+    ): Promise<Buffer>;
+
+    /**
+     * Asynchronous readlink(2) - read value of a symbolic link.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function readlink(
+      path: PathLike,
+      options?: { encoding?: string | null } | string | null
+    ): Promise<string | Buffer>;
+
+    /**
+     * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
+     * @param target A path to an existing file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to the new symlink. If a URL is provided, it must use the `file:` protocol.
+     * @param type May be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
+     * When using `'junction'`, the `target` argument will automatically be normalized to an absolute path.
+     */
+    function symlink(
+      target: PathLike,
+      path: PathLike,
+      type?: string | null
+    ): Promise<void>;
+
+    /**
+     * Asynchronous fstat(2) - Get file status.
+     * @param handle A `FileHandle`.
+     */
+    function fstat(handle: FileHandle): Promise<Stats>;
+
+    /**
+     * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function lstat(path: PathLike): Promise<Stats>;
+
+    /**
+     * Asynchronous stat(2) - Get file status.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function stat(path: PathLike): Promise<Stats>;
+
+    /**
+     * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.
+     * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
+
+    /**
+     * Asynchronous unlink(2) - delete a name and possibly the file it refers to.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function unlink(path: PathLike): Promise<void>;
+
+    /**
+     * Asynchronous fchmod(2) - Change permissions of a file.
+     * @param handle A `FileHandle`.
+     * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+     */
+    function fchmod(handle: FileHandle, mode: string | number): Promise<void>;
+
+    /**
+     * Asynchronous chmod(2) - Change permissions of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+     */
+    function chmod(path: PathLike, mode: string | number): Promise<void>;
+
+    /**
+     * Asynchronous lchmod(2) - Change permissions of a file. Does not dereference symbolic links.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
+     */
+    function lchmod(path: PathLike, mode: string | number): Promise<void>;
+
+    /**
+     * Asynchronous lchown(2) - Change ownership of a file. Does not dereference symbolic links.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function lchown(path: PathLike, uid: number, gid: number): Promise<void>;
+
+    /**
+     * Asynchronous fchown(2) - Change ownership of a file.
+     * @param handle A `FileHandle`.
+     */
+    function fchown(
+      handle: FileHandle,
+      uid: number,
+      gid: number
+    ): Promise<void>;
+
+    /**
+     * Asynchronous chown(2) - Change ownership of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    function chown(path: PathLike, uid: number, gid: number): Promise<void>;
+
+    /**
+     * Asynchronously change file timestamps of the file referenced by the supplied path.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    function utimes(
+      path: PathLike,
+      atime: string | number | Date,
+      mtime: string | number | Date
+    ): Promise<void>;
+
+    /**
+     * Asynchronously change file timestamps of the file referenced by the supplied `FileHandle`.
+     * @param handle A `FileHandle`.
+     * @param atime The last access time. If a string is provided, it will be coerced to number.
+     * @param mtime The last modified time. If a string is provided, it will be coerced to number.
+     */
+    function futimes(
+      handle: FileHandle,
+      atime: string | number | Date,
+      mtime: string | number | Date
+    ): Promise<void>;
+
+    /**
+     * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function realpath(
+      path: PathLike,
+      options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    ): Promise<string>;
+
+    /**
+     * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function realpath(
+      path: PathLike,
+      options: { encoding: "buffer" } | "buffer"
+    ): Promise<Buffer>;
+
+    /**
+     * Asynchronous realpath(3) - return the canonicalized absolute pathname.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function realpath(
+      path: PathLike,
+      options?: { encoding?: string | null } | string | null
+    ): Promise<string | Buffer>;
+
+    /**
+     * Asynchronously creates a unique temporary directory.
+     * Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function mkdtemp(
+      prefix: string,
+      options?: { encoding?: BufferEncoding | null } | BufferEncoding | null
+    ): Promise<string>;
+
+    /**
+     * Asynchronously creates a unique temporary directory.
+     * Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function mkdtemp(
+      prefix: string,
+      options: { encoding: "buffer" } | "buffer"
+    ): Promise<Buffer>;
+
+    /**
+     * Asynchronously creates a unique temporary directory.
+     * Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    function mkdtemp(
+      prefix: string,
+      options?: { encoding?: string | null } | string | null
+    ): Promise<string | Buffer>;
+
+    /**
+     * Asynchronously writes data to a file, replacing the file if it already exists.
+     * It is unsafe to call `fsPromises.writeFile()` multiple times on the same file without waiting for the `Promise` to be resolved (or rejected).
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * If a `FileHandle` is provided, the underlying file will _not_ be closed automatically.
+     * @param data The data to write. If something other than a `Buffer` or `Uint8Array` is provided, the value is coerced to a string.
+     * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+     * If `encoding` is not supplied, the default of `'utf8'` is used.
+     * If `mode` is not supplied, the default of `0o666` is used.
+     * If `mode` is a string, it is parsed as an octal integer.
+     * If `flag` is not supplied, the default of `'w'` is used.
+     */
+    function writeFile(
+      path: PathLike | FileHandle,
+      data: any,
+      options?:
+        | {
+            encoding?: string | null;
+            mode?: string | number;
+            flag?: string | number;
+          }
+        | string
+        | null
+    ): Promise<void>;
+
+    /**
+     * Asynchronously append data to a file, creating the file if it does not exist.
+     * @param file A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * URL support is _experimental_.
+     * If a `FileHandle` is provided, the underlying file will _not_ be closed automatically.
+     * @param data The data to write. If something other than a `Buffer` or `Uint8Array` is provided, the value is coerced to a string.
+     * @param options Either the encoding for the file, or an object optionally specifying the encoding, file mode, and flag.
+     * If `encoding` is not supplied, the default of `'utf8'` is used.
+     * If `mode` is not supplied, the default of `0o666` is used.
+     * If `mode` is a string, it is parsed as an octal integer.
+     * If `flag` is not supplied, the default of `'a'` is used.
+     */
+    function appendFile(
+      path: PathLike | FileHandle,
+      data: any,
+      options?:
+        | {
+            encoding?: string | null;
+            mode?: string | number;
+            flag?: string | number;
+          }
+        | string
+        | null
+    ): Promise<void>;
+
+    /**
+     * Asynchronously reads the entire contents of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * If a `FileHandle` is provided, the underlying file will _not_ be closed automatically.
+     * @param options An object that may contain an optional flag.
+     * If a flag is not provided, it defaults to `'r'`.
+     */
+    function readFile(
+      path: PathLike | FileHandle,
+      options?: { encoding?: null; flag?: string | number } | null
+    ): Promise<Buffer>;
+
+    /**
+     * Asynchronously reads the entire contents of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * If a `FileHandle` is provided, the underlying file will _not_ be closed automatically.
+     * @param options An object that may contain an optional flag.
+     * If a flag is not provided, it defaults to `'r'`.
+     */
+    function readFile(
+      path: PathLike | FileHandle,
+      options:
+        | { encoding: BufferEncoding; flag?: string | number }
+        | BufferEncoding
+    ): Promise<string>;
+
+    /**
+     * Asynchronously reads the entire contents of a file.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * If a `FileHandle` is provided, the underlying file will _not_ be closed automatically.
+     * @param options An object that may contain an optional flag.
+     * If a flag is not provided, it defaults to `'r'`.
+     */
+    function readFile(
+      path: PathLike | FileHandle,
+      options?:
+        | { encoding?: string | null; flag?: string | number }
+        | string
+        | null
+    ): Promise<string | Buffer>;
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "original-fs";
 import * as path from "path";
 import * as util from "util";
 import { commands, Event, window } from "vscode";

--- a/tslint.json
+++ b/tslint.json
@@ -34,7 +34,8 @@
         ["String", "Avoid using the `String` type. Did you mean `string`?"],
         ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"]
       ]
-    }
+    },
+    "import-blacklist": [true, "fs"]
   },
   "rulesDirectory": [],
   "linterOptions": {


### PR DESCRIPTION
* Fixed .asar file locking
* Replaced all usage of `"fs"` with `"original-fs"`
* Blacklisted usage of `"fs"` module

https://electronjs.org/docs/tutorial/application-packaging#treating-an-asar-archive-as-a-normal-file