### PR TITLE
fix bug,while svn path contains @

### DIFF
--- a/src/svn.ts
+++ b/src/svn.ts
@@ -126,6 +126,7 @@ export class Svn {
     if (cwd) {
       defaults.cwd = cwd;
     }
+    args = args.map(x => (/@/.test(x) && !/@\d+$/.test(x)) ? x + "@" : x);
     const process = cp.spawn(this.svnPath, args, defaults);
 
     const disposables: IDisposable[] = [];


### PR DESCRIPTION
i have a repository like url://repository/foo/@bar, the extension not work, because:
```
svn info --xml foo/@bar --non-interactive
``` 
failed with 
```
svn: E200009: 'foo/@bar': a peg revision is not allowed here
```
add an "@" will work
```
svn info --xml foo/@bar@ --non-interactive
``` 