### PR TITLE
refactor: Refactored usage of vscode modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2765,7 +2765,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2786,12 +2787,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2806,17 +2809,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2933,7 +2939,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2945,6 +2952,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2959,6 +2967,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2966,12 +2975,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2990,6 +3001,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3070,7 +3082,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3082,6 +3095,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3167,7 +3181,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3203,6 +3218,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3222,6 +3238,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3265,12 +3282,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "cz-conventional-changelog": "^2.1.0",
     "decache": "^4.5.1",
     "glob": "^7.1.4",
-    "iconv-lite": "^0.4.23",
     "istanbul": "^0.4.5",
     "mocha": "^6.1.4",
     "mocha-junit-reporter": "^1.22.0",

--- a/src/svn.ts
+++ b/src/svn.ts
@@ -1,22 +1,8 @@
-/**
- * Load local first, after load the from VSCode modules
- * == 0 - is svn-scm/out/node_modules
- * == 1 - is svn-scm/node_modules
- * == 2 - is vscode folder
- * >= 3 - parent folders of svn-scm
- */
-import * as vscode from "vscode";
-module.paths.splice(2, 0, `${vscode.env.appRoot}/node_modules.asar`);
-module.paths.splice(2, 0, `${vscode.env.appRoot}/node_modules`); // VSCode < 1.21.0
-
 import * as cp from "child_process";
 import { EventEmitter } from "events";
-import * as iconv from "iconv-lite";
 import isUtf8 = require("is-utf8");
-import * as jschardet from "jschardet";
 import * as proc from "process";
 import { Readable } from "stream";
-import { Uri, workspace } from "vscode";
 import {
   ConstructorPolicy,
   ICpOptions,
@@ -28,6 +14,7 @@ import { parseInfoXml } from "./infoParser";
 import SvnError from "./svnError";
 import { Repository } from "./svnRepository";
 import { dispose, IDisposable, toDisposable } from "./util";
+import { iconv, jschardet } from "./vscodeModules";
 
 export const svnErrorCodes: { [key: string]: string } = {
   AuthorizationFailed: "E170001",
@@ -182,8 +169,8 @@ export class Svn {
         if (!iconv.encodingExists(defaultEncoding)) {
           this.logOutput(
             "svn.default.encoding: Invalid Parameter: '" +
-              defaultEncoding +
-              "'.\n"
+            defaultEncoding +
+            "'.\n"
           );
         } else if (!isUtf8(stdout)) {
           encoding = defaultEncoding;

--- a/src/types/iconv-lite.d.ts
+++ b/src/types/iconv-lite.d.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types='node'/>
+
+declare module "iconv-lite" {
+  export function decode(buffer: Buffer, encoding: string): string;
+
+  export function encode(
+    content: string | Buffer,
+    encoding: string,
+    options?: { addBOM?: boolean }
+  ): Buffer;
+
+  export function encodingExists(encoding: string): boolean;
+
+  export function decodeStream(encoding: string): NodeJS.ReadWriteStream;
+
+  export function encodeStream(
+    encoding: string,
+    options?: { addBOM?: boolean }
+  ): NodeJS.ReadWriteStream;
+}

--- a/src/vscodeModules.ts
+++ b/src/vscodeModules.ts
@@ -1,0 +1,18 @@
+// Only this file is allowed to import VSCode modules
+// tslint:disable: import-blacklist
+
+import * as path from "path";
+import * as vscode from "vscode";
+
+const appRoot = vscode.env.appRoot;
+
+// Try load only in VSCode node_modules, like .vsix files (without dev dependencies)
+module.paths = [
+  path.join(appRoot, "node_modules.asar"),
+  path.join(appRoot, "node_modules"), // VSCode < 1.21.0
+];
+
+import * as iconv from "iconv-lite";
+import * as jschardet from "jschardet";
+
+export { iconv, jschardet };

--- a/tslint.json
+++ b/tslint.json
@@ -35,7 +35,7 @@
         ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"]
       ]
     },
-    "import-blacklist": [true, "fs"]
+    "import-blacklist": [true, "fs", "iconv-lite", "jschardet"]
   },
   "rulesDirectory": [],
   "linterOptions": {


### PR DESCRIPTION
* Removed dev dependency of `iconv-lite` in favor `iconv-lite.d.ts`
* Deny direct import for `iconv-lite` and `jschardet`
* Don't try load vscode modules from `node_modules` directory