### PR TITLE
fix: Improved commit message notification (close #545)

### DIFF
--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -284,11 +284,11 @@ export class Repository {
 
     const matches = result.stdout.match(/Committed revision (.*)\./i);
     if (matches && matches[0]) {
-      const sendedFiles = (result.stdout.match(/(Sending\s+)/g) || []).length;
+      const sendedFiles = (result.stdout.match(/(Sending|Adding|Deleting)\s+/g) || []).length;
 
       const filesMessage = `${sendedFiles} ${sendedFiles === 1 ? "file" : "files"} commited`;
 
-      return `${filesMessage}: revision ${matches[1]}`;
+      return `${filesMessage}: revision ${matches[1]}.`;
     }
 
     return result.stdout;

--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -284,7 +284,11 @@ export class Repository {
 
     const matches = result.stdout.match(/Committed revision (.*)\./i);
     if (matches && matches[0]) {
-      return matches[0];
+      const sendedFiles = (result.stdout.match(/(Sending\s+)/g) || []).length;
+
+      const filesMessage = `${sendedFiles} ${sendedFiles === 1 ? "file" : "files"} commited`;
+
+      return `${filesMessage}: revision ${matches[1]}`;
     }
 
     return result.stdout;

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -109,7 +109,7 @@ suite("Repository Tests", () => {
     assert.equal(repository.changes.resourceStates.length, 1);
 
     const message = await repository.commitFiles("First Commit", [file]);
-    assert.ok(/Committed revision (.*)\./i.test(message));
+    assert.ok(/1 file commited: revision (.*)\./i.test(message));
 
     assert.equal(repository.changes.resourceStates.length, 0);
 


### PR DESCRIPTION
New format: `<n> files commited: revision <i>`, where `<n>` is the number of sended files and `<i>` the commited revision