### PR TITLE
Fix trying to open every file as a repo (close #621)

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -242,7 +242,7 @@ export class Model implements IDisposable {
 
     const checkParent = level === 0;
 
-    if (isSvnFolder(path, checkParent)) {
+    if (await isSvnFolder(path, checkParent)) {
       // Config based on folder path
       const resourceConfig = workspace.getConfiguration("svn", Uri.file(path));
 


### PR DESCRIPTION
The code missed an "await" at the place where the new isSvnFolder
function is used.  Function isSvnFolder always returns a valid
Promise, which was treated like a boolean "true" in the "if".