### PR TITLE
Fix commit icon for undefined author

### DIFF
--- a/src/historyView/common.ts
+++ b/src/historyView/common.ts
@@ -199,7 +199,7 @@ export function getCommitIcon(
   size: number = 16
 ): Uri | { light: Uri; dark: Uri } {
   if (
-    !configuration.get("gravatars.enabled", true) as boolean ||
+    (!configuration.get("gravatars.enabled", true) as boolean) ||
     author === undefined
   ) {
     return getIconObject("icon-commit");

--- a/src/historyView/common.ts
+++ b/src/historyView/common.ts
@@ -198,7 +198,10 @@ export function getCommitIcon(
   author: string,
   size: number = 16
 ): Uri | { light: Uri; dark: Uri } {
-  if (!configuration.get("gravatars.enabled", true) as boolean) {
+  if (
+    !configuration.get("gravatars.enabled", true) as boolean ||
+    author === undefined
+  ) {
     return getIconObject("icon-commit");
   }
 


### PR DESCRIPTION
If a commit has no author defined, getCommitIcon would finally crash
at creating the md5 of undefined.  With this patch the non-gravatar
default icon is used instead, for commits with an undefined author.