### PR TITLE
chore: Stop greenkeeper updates vscode types

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
       "path": "cz-conventional-changelog"
     }
   },
+  "greenkeeper": {
+    "ignore": [
+      "@types/vscode"
+    ]
+  },
   "contributes": {
     "viewsContainers": {
       "activitybar": [


### PR DESCRIPTION
@types/vscode version needs to match engine req in package.json