### PR TITLE
chore: Stop greenkeeper updates node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -460,9 +460,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.10.tgz",
-      "integrity": "sha512-ObiPa43kJCkgjG+7usRCoxWhqKCmT5JWvi+8bg54KMkP2CvTliYLmKR9uHLaz+51JDOX/8MjWc6Xz18xHTs7XQ==",
+      "version": "8.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
+      "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/glob": "^7.1.1",
     "@types/istanbul": "^0.4.30",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^12.7.10",
+    "@types/node": "8.9.5",
     "@types/semver": "^6.0.0",
     "@types/tmp": "0.1.0",
     "@types/vscode": "1.26.0",
@@ -90,6 +90,7 @@
   },
   "greenkeeper": {
     "ignore": [
+      "@types/node",
       "@types/vscode"
     ]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "allowUnreachableCode": false
+    "allowUnreachableCode": false,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
The current version of NODE in vscode "1.26.x" is "8.9.x", look: https://code.visualstudio.com/updates/v1_26#_nodejs-update

The next update of NODE is in:
 * vscode "1.31": https://code.visualstudio.com/updates/v1_31#_nodejs-update
 * vscode "1.36": https://code.visualstudio.com/updates/v1_36

If in the future want update the minimal version of VSCODE, is good to update the value of `target` in `tsconfig.json`
 