### PR TITLE
checking for lock field when parsing xml entries

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -161,6 +161,7 @@ export interface IEntry {
   reposStatus?: {
     props: string;
     item: string;
+    lock?: object;
   };
 }
 

--- a/src/statusParser.ts
+++ b/src/statusParser.ts
@@ -18,7 +18,7 @@ function processEntry(
   }
 
   const wcStatus: IWcStatus = {
-    locked: !!entry.wcStatus.wcLocked && entry.wcStatus.wcLocked === "true",
+    locked: !!entry.wcStatus.wcLocked && entry.wcStatus.wcLocked === "true" || !!(entry.reposStatus && entry.reposStatus.lock),
     switched: !!entry.wcStatus.switched && entry.wcStatus.switched === "true"
   };
 


### PR DESCRIPTION
Lock status was not properly recognized when 'lock' object was present in the status response from the server.

Doesn't implement #624, but helps with the locks issue mentioned there.