### PR TITLE
chore: build now uses macos latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, macOS-10.14, windows-2019]
+        os: [ubuntu-16.04, macOS-latest, windows-2019]
         version: ['1.26.0', '', 'insiders']
 
     steps:


### PR DESCRIPTION
fixes #717 