### PR TITLE
fix: Stop retrieving info of repo root

### DIFF
--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -56,7 +56,8 @@ export class Repository {
   public async updateInfo() {
     const result = await this.exec([
       "info",
-      "--xml"
+      "--xml",
+      fixPegRevision(this.workspaceRoot)
     ]);
     this._info = await parseInfoXml(result.stdout);
   }

--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -56,8 +56,7 @@ export class Repository {
   public async updateInfo() {
     const result = await this.exec([
       "info",
-      "--xml",
-      fixPegRevision(this.root)
+      "--xml"
     ]);
     this._info = await parseInfoXml(result.stdout);
   }


### PR DESCRIPTION
Currently, if you have just the root of your repository checked out and you use svn update to "checkout" each branch (instead of having multiple checked out branches, e.g.), the extension doesn't correctly show the current branch when looking at the logs. Instead, it shows the logs for the root of the repo, which is not right.

This MR makes svn info run in the workspaceRoot, instead of the repo root.