### PR TITLE
Fix relative paths and added files

### DIFF
--- a/src/historyView/repoLogProvider.ts
+++ b/src/historyView/repoLogProvider.ts
@@ -292,8 +292,7 @@ export class RepoLogProvider
         if (revs.length === 2) {
           prevRev = revs[1];
         } else {
-          window.showWarningMessage("Cannot find previous commit");
-          return;
+          return this.openFileLocal(element);
         }
       }
     }

--- a/src/svnRI.ts
+++ b/src/svnRI.ts
@@ -33,6 +33,7 @@ export class SvnRI {
     return Uri.file(
       path.join(
         this.checkoutRoot.path,
+        this.fromRepoToBranch,
         path.relative(this.fromRepoToBranch, this._path)
       )
     );


### PR DESCRIPTION
This PR does two things:

- Fixes calculation of local file paths relative to the branch root (probably caused by #728)
- Instead of erroring with "no previous commit" for added files, just open the file.