### PR TITLE
fix: Fix cwd when running svn commands for remoteRepository

### DIFF
--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -62,8 +62,9 @@ export class Repository {
     const result = await this.exec([
       "info",
       "--xml",
-      fixPegRevision(this.workspaceRoot)
+      fixPegRevision(this.workspaceRoot ? this.workspaceRoot : this.root)
     ]);
+
     this._info = await parseInfoXml(result.stdout);
   }
 


### PR DESCRIPTION
Found an issue with pull request #728. The CWD is wrong when running commands against a URL.