### PR TITLE
fix: Use remote URI to retrieve file for repo log

### DIFF
--- a/src/historyView/repoLogProvider.ts
+++ b/src/historyView/repoLogProvider.ts
@@ -268,29 +268,20 @@ export class RepoLogProvider
     const commit = element.data as ISvnLogEntryPath;
     const item = this.getCached(element);
     const parent = (element.parent as ILogTreeItem).data as ISvnLogEntry;
-    const remotePath =  item.repo.getPathNormalizer().parse(commit._).remoteFullPath;
+    const remotePath = item.repo.getPathNormalizer().parse(commit._)
+      .remoteFullPath;
     let prevRev: ISvnLogEntry;
 
-    const revs = await item.repo.log(
-        parent.revision,
-        "1",
-        2,
-        remotePath
-    );
+    const revs = await item.repo.log(parent.revision, "1", 2, remotePath);
 
     if (revs.length === 2) {
-        prevRev = revs[1];
+      prevRev = revs[1];
     } else {
-        window.showWarningMessage("Cannot find previous commit");
-        return;
+      window.showWarningMessage("Cannot find previous commit");
+      return;
     }
 
-    return openDiff(
-      item.repo,
-      remotePath,
-      prevRev.revision,
-      parent.revision
-    );
+    return openDiff(item.repo, remotePath, prevRev.revision, parent.revision);
   }
 
   public async refresh(element?: ILogTreeItem, fetchMoreClick?: boolean) {

--- a/src/historyView/repoLogProvider.ts
+++ b/src/historyView/repoLogProvider.ts
@@ -271,30 +271,13 @@ export class RepoLogProvider
     const remotePath =  item.repo.getPathNormalizer().parse(commit._).remoteFullPath;
     let prevRev: ISvnLogEntry;
 
-    {
-      // find prevRev scope
-      const pos = item.entries.findIndex(e => e === parent);
-      let posPrev: number | undefined;
-      for (
-        let i = pos + 1;
-        posPrev === undefined && i < item.entries.length;
-        i++
-      ) {
-        for (const p of item.entries[i].paths) {
-          if (p._ === commit._) {
-            posPrev = i;
-            break;
-          }
-        }
-      }
-    }
-
     const revs = await item.repo.log(
         parent.revision,
         "1",
         2,
         remotePath
     );
+
     if (revs.length === 2) {
         prevRev = revs[1];
     } else {


### PR DESCRIPTION
This fixes being unable to diff a file between revisions due to sparse checkout. Instead of trying to figure out where the file lives on the filesystem, we'll simply use the remote URI to diff the file.