### PR TITLE
fix: added experimental encoding priority list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1071,6 +1071,14 @@
                     "description": "Try the experimental encoding detection",
                     "default": false
                 },
+                "svn.experimental.encoding_priority": {
+                    "type":"array",
+                    "description": "Priority of encoding",
+                    "default": [],
+                    "examples": [
+                        ["UTF-8", "GB18030", "windows-1251"]
+                    ]
+                },
                 "svn.gravatar.icon_url": {
                     "type": "string",
                     "description": "Url for the gravitar icon using the <AUTHOR>, <AUTHOR_MD5> and <SIZE> placeholders",

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -58,7 +58,7 @@ export function detectEncoding(buffer: Buffer): string | null {
     false
   );
   if (experimental) {
-    let detected = chardet.detectAll(buffer);
+    const detected = chardet.detectAll(buffer);
     const encodingPriorities = configuration.get<string[]>(
       "experimental.encoding_priority",
       []

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -46,6 +46,10 @@ const JSCHARDET_TO_ICONV_ENCODINGS: { [name: string]: string } = {
   big5: "cp950"
 };
 
+function normaliseEncodingName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
 export function detectEncoding(buffer: Buffer): string | null {
   const result = detectEncodingByBOM(buffer);
 
@@ -70,8 +74,8 @@ export function detectEncoding(buffer: Buffer): string | null {
 
     for (const pri of encodingPriorities) {
       for (const det of detected) {
-        if (pri === det.name) {
-          return det.name.replace(/[^a-zA-Z0-9]/g, "").toLocaleLowerCase();
+        if (normaliseEncodingName(pri) === normaliseEncodingName(det.name)) {
+          return normaliseEncodingName(det.name);
         }
       }
     }
@@ -93,9 +97,7 @@ export function detectEncoding(buffer: Buffer): string | null {
     return null;
   }
 
-  const normalizedEncodingName = encoding
-    .replace(/[^a-zA-Z0-9]/g, "")
-    .toLowerCase();
+  const normalizedEncodingName = normaliseEncodingName(encoding);
   const mapped = JSCHARDET_TO_ICONV_ENCODINGS[normalizedEncodingName];
 
   return mapped || normalizedEncodingName;

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -58,9 +58,22 @@ export function detectEncoding(buffer: Buffer): string | null {
     false
   );
   if (experimental) {
-    const detected = chardet.detect(buffer);
-    if (detected) {
-      return detected.replace(/[^a-zA-Z0-9]/g, "").toLocaleLowerCase();
+    let detected = chardet.detectAll(buffer);
+    const encodingPriorities = configuration.get<string[]>(
+      "experimental.encoding_priority",
+      []
+    );
+
+    if (!detected) {
+      return null;
+    }
+
+    for (const pri of encodingPriorities) {
+      for (const det of detected) {
+        if (pri === det.name) {
+          return det.name.replace(/[^a-zA-Z0-9]/g, "").toLocaleLowerCase();
+        }
+      }
     }
 
     return null;


### PR DESCRIPTION
This adds a new config option `svn.experimental.encoding_priority` which takes an array of encoding types and prioritise them based on order. For example `["UTF-8", "GB18030", "windows-1251"]` will prioritise `UFT-8` then `GB18030` ect. If there are no matches it will just return null and will either use `default.encoding` or `UTF-8`.