### PR TITLE
fix: use matchBase option when match ignoreList

### DIFF
--- a/package.json
+++ b/package.json
@@ -1291,7 +1291,7 @@
                     "default": [],
                     "examples": [
                         [
-                            "**/*.js",
+                            "*.js",
                             "/log",
                             "/.vscode/*",
                             "!/.vscode/settings.json"

--- a/package.json
+++ b/package.json
@@ -1291,7 +1291,8 @@
                     "default": [],
                     "examples": [
                         [
-                            "*.js",
+                            "**/*.js",
+                            "*.jar",
                             "/log",
                             "/.vscode/*",
                             "!/.vscode/settings.json"

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -585,7 +585,10 @@ export class Repository implements IRemoteRepository {
         }
         if (
           ignoreList.length > 0 &&
-          matchAll(path.sep + status.path, ignoreList, { dot: true })
+          matchAll(path.sep + status.path, ignoreList, {
+            dot: true,
+            matchBase: true
+          })
         ) {
           continue;
         }

--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -486,7 +486,12 @@ export class Repository {
             (await readdir(file)).map(subfile => {
               const abspath = path.resolve(file + path.sep + subfile);
               const relpath = this.removeAbsolutePath(abspath);
-              if (!matchAll(path.sep + relpath, ignoreList, { dot: true })) {
+              if (
+                !matchAll(path.sep + relpath, ignoreList, {
+                  dot: true,
+                  matchBase: true
+                })
+              ) {
                 return allFiles(abspath);
               }
               return [];


### PR DESCRIPTION
I think use `matchBase` option is better.