### PR TITLE
onPossibleSvnRepositoryChange triggers only on directories

### DIFF
--- a/src/source_control_manager.ts
+++ b/src/source_control_manager.ts
@@ -1,4 +1,4 @@
-import { Stats } from "original-fs";
+import { Stats, statSync } from "original-fs";
 import * as path from "path";
 import {
   commands,
@@ -167,7 +167,10 @@ export class SourceControlManager implements IDisposable {
     );
     const onPossibleSvnRepositoryChange = filterEvent(
       onWorkspaceChange,
-      uri => uri.scheme === "file" && !this.getRepository(uri)
+      uri =>
+        uri.scheme === "file" &&
+        statSync(uri.fsPath).isDirectory() &&
+        !this.getRepository(uri)
     );
     onPossibleSvnRepositoryChange(
       this.onPossibleSvnRepositoryChange,


### PR DESCRIPTION
This change targets same issue as #891 in simpler manner.
To check if another repo has been added to the workspace, checking directory FS events is enough.
This should reduce CPU usage when a lot of FS events are being fired (e.g compilation, or corporate antivirus scan).

