### PR TITLE
fix: add --limit=1 when determining branch copy source

### DIFF
--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -196,6 +196,7 @@ export class Repository {
     let args = [
       "log",
       "-r1:HEAD",
+      "--limit=1",
       "--stop-on-copy",
       "--xml",
       "--with-all-revprops",


### PR DESCRIPTION
When determining if a branch is a copy, the entire log is fetched, but only the first commit is checked. This is problematic if the branch is not a copy, and the commit log is massive. A large enough log will currently crash VS Code. 

This fix limits pulling only the first log. Fixes #1539 

