### PR TITLE
Adds Selected Revisions to SVN Panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -897,6 +897,18 @@
                     "command": "svn.revisionviewer.remove",
                     "when": "view == revisionviewer && viewItem != diffable",
                     "group": "inline"
+                },
+                {
+                    "command": "svn.repolog.copymsg",
+                    "when": "view == revisionviewer && viewItem == commit"
+                },
+                {
+                    "command": "svn.repolog.copyrevision",
+                    "when": "view == revisionviewer && viewItem == commit"
+                },
+                {
+                    "command": "svn.repolog.openDiff",
+                    "when": "view == revisionviewer && viewItem == diffable"
                 }
             ],
             "scm/title": [

--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
                     "id": "branchchanges",
                     "name": "Branch Changes",
                     "when": "config.svn.enabled && svnOpenRepositoryCount != 0"
+                },
+                {
+                    "id": "revisionviewer",
+                    "name": "Selected Revisions",
+                    "when": "config.svn.enabled && svnOpenRepositoryCount != 0"
                 }
             ]
         },
@@ -221,6 +226,11 @@
                 "command": "svn.itemlog.copyrevision",
                 "category": "SVN",
                 "title": "Copy revision number"
+            },
+            {
+                "command": "svn.itemlog.addrevision",
+                "category": "SVN",
+                "title": "Add to selected revisions"
             },
             {
                 "command": "svn.itemlog.openDiff",
@@ -370,6 +380,11 @@
                 "title": "Copy revision number"
             },
             {
+                "command": "svn.repolog.addrevision",
+                "category": "SVN",
+                "title": "Add to selected revisions"
+            },
+            {
                 "command": "svn.repolog.openDiff",
                 "category": "SVN",
                 "title": "Open diff"
@@ -397,6 +412,11 @@
                 "command": "svn.repolog.remove",
                 "category": "SVN",
                 "title": "Remove"
+            },
+            {
+                "command": "svn.revisionviewer.addrevision",
+                "category": "SVN",
+                "title": "Add to selected revisions"
             },
             {
                 "command": "svn.resolve",
@@ -550,6 +570,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "svn.itemlog.addrevision",
+                    "when": "false"
+                },
+                {
                     "command": "svn.itemlog.openDiff",
                     "when": "false"
                 },
@@ -639,6 +663,10 @@
                 },
                 {
                     "command": "svn.repolog.copyrevision",
+                    "when": "false"
+                },
+                {
+                    "command": "svn.repolog.addrevision",
                     "when": "false"
                 },
                 {
@@ -781,6 +809,10 @@
                     "when": "view == itemlog && viewItem == diffable"
                 },
                 {
+                    "command": "svn.itemlog.addrevision",
+                    "when": "view == itemlog && viewItem == diffable"
+                },
+                {
                     "command": "svn.repolog.openDiff",
                     "when": "view == repolog && viewItem == diffable"
                 },
@@ -802,6 +834,10 @@
                 },
                 {
                     "command": "svn.repolog.copyrevision",
+                    "when": "view == repolog && viewItem == commit"
+                },
+                {
+                    "command": "svn.repolog.addrevision",
                     "when": "view == repolog && viewItem == commit"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -387,7 +387,7 @@
             {
                 "command": "svn.repolog.selectrevision",
                 "category": "SVN",
-                "title": "Select revision",
+                "title": "Add revision",
                 "icon": {
                     "dark": "icons/dark/add.svg",
                     "light": "icons/light/add.svg"
@@ -420,12 +420,25 @@
             {
                 "command": "svn.repolog.remove",
                 "category": "SVN",
-                "title": "Remove"
+                "title": "Remove",
+                "icon": "$(close)"
             },
             {
                 "command": "svn.revisionviewer.addrevision",
                 "category": "SVN",
                 "title": "Add to selected revisions"
+            },
+            {
+                "command": "svn.revisionviewer.remove",
+                "category": "SVN",
+                "title": "Remove",
+                "icon": "$(close)"
+            },
+            {
+                "command": "svn.revisionviewer.removeall",
+                "category": "SVN",
+                "title": "Remove all",
+                "icon": "$(close-all)"
             },
             {
                 "command": "svn.resolve",
@@ -703,6 +716,14 @@
                     "when": "false"
                 },
                 {
+                    "command": "svn.revisionviewer.remove",
+                    "when": "false"
+                },
+                {
+                    "command": "svn.revisionviewer.removeall",
+                    "when": "false"
+                },
+                {
                     "command": "svn.resolve",
                     "when": "config.svn.enabled && svnOpenRepositoryCount != 0"
                 },
@@ -760,17 +781,12 @@
                 {
                     "command": "svn.repolog.refresh",
                     "when": "view == repolog",
-                    "group": "navigation"
+                    "group": "navigation@2"
                 },
                 {
                     "command": "svn.repolog.addrepolike",
                     "when": "view == repolog",
-                    "group": "navigation"
-                },
-                {
-                    "command": "svn.repolog.selectrevision",
-                    "when": "view == revisionviewer",
-                    "group": "navigation"
+                    "group": "navigation@1"
                 },
                 {
                     "command": "svn.itemlog.refresh",
@@ -781,6 +797,16 @@
                     "command": "svn.branchchanges.refresh",
                     "when": "view == branchchanges",
                     "group": "navigation"
+                },
+                {
+                    "command": "svn.repolog.selectrevision",
+                    "when": "view == revisionviewer",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "svn.revisionviewer.removeall",
+                    "when": "view == revisionviewer",
+                    "group": "navigation@2"
                 }
             ],
             "view/item/context": [
@@ -803,6 +829,11 @@
                 {
                     "command": "svn.repolog.remove",
                     "when": "view == repolog && viewItem == userrepo"
+                },
+                {
+                    "command": "svn.repolog.remove",
+                    "when": "view == repolog && viewItem == userrepo",
+                    "group": "inline"
                 },
                 {
                     "command": "svn.itemlog.openFileRemote",
@@ -857,6 +888,15 @@
                 {
                     "command": "svn.repolog.addrevision",
                     "when": "view == repolog && viewItem == commit"
+                },
+                {
+                    "command": "svn.revisionviewer.remove",
+                    "when": "view == revisionviewer && viewItem != diffable"
+                },
+                {
+                    "command": "svn.revisionviewer.remove",
+                    "when": "view == revisionviewer && viewItem != diffable",
+                    "group": "inline"
                 }
             ],
             "scm/title": [

--- a/package.json
+++ b/package.json
@@ -385,6 +385,15 @@
                 "title": "Add to selected revisions"
             },
             {
+                "command": "svn.repolog.selectrevision",
+                "category": "SVN",
+                "title": "Select revision",
+                "icon": {
+                    "dark": "icons/dark/add.svg",
+                    "light": "icons/light/add.svg"
+                }
+            },
+            {
                 "command": "svn.repolog.openDiff",
                 "category": "SVN",
                 "title": "Open diff"
@@ -690,6 +699,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "svn.revisionviewer.addrevision",
+                    "when": "false"
+                },
+                {
                     "command": "svn.resolve",
                     "when": "config.svn.enabled && svnOpenRepositoryCount != 0"
                 },
@@ -752,6 +765,11 @@
                 {
                     "command": "svn.repolog.addrepolike",
                     "when": "view == repolog",
+                    "group": "navigation"
+                },
+                {
+                    "command": "svn.repolog.selectrevision",
+                    "when": "view == revisionviewer",
                     "group": "navigation"
                 },
                 {

--- a/src/commands/search_log_by_revision.ts
+++ b/src/commands/search_log_by_revision.ts
@@ -4,6 +4,7 @@ import { window, Uri, commands } from "vscode";
 import { Repository } from "../repository";
 import { toSvnUri } from "../uri";
 import { SvnUriAction } from "../common/types";
+import { getRevision } from "../util";
 
 export class SearchLogByRevision extends Command {
   constructor() {
@@ -16,8 +17,8 @@ export class SearchLogByRevision extends Command {
       return;
     }
 
-    const revision = parseInt(input, 10);
-    if (!revision || !/^\+?(0|[1-9]\d*)$/.test(input)) {
+    const revision = getRevision(input);
+    if (!revision) {
       window.showErrorMessage("Invalid revision");
       return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { OpenRepositoryCount } from "./contexts/openRepositoryCount";
 import { configuration } from "./helpers/configuration";
 import { ItemLogProvider } from "./historyView/itemLogProvider";
 import { RepoLogProvider } from "./historyView/repoLogProvider";
+import { RevisionViewerProvider } from "./historyView/revisionViewerProvider";
 import * as messages from "./messages";
 import { SourceControlManager } from "./source_control_manager";
 import { Svn } from "./svn";
@@ -51,6 +52,7 @@ async function init(
     new RepoLogProvider(sourceControlManager),
     new ItemLogProvider(sourceControlManager),
     new BranchChangesProvider(sourceControlManager),
+    new RevisionViewerProvider(),
     new CheckActiveEditor(sourceControlManager),
     new OpenRepositoryCount(sourceControlManager),
     new IsSvn18orGreater(info.version),

--- a/src/historyView/common.ts
+++ b/src/historyView/common.ts
@@ -78,6 +78,28 @@ export function getIconObject(iconName: string): { light: Uri; dark: Uri } {
   };
 }
 
+export function getActionIcon(action: string) {
+  let name: string | undefined;
+  switch (action) {
+    case "A":
+      name = "status-added";
+      break;
+    case "D":
+      name = "status-deleted";
+      break;
+    case "M":
+      name = "status-modified";
+      break;
+    case "R":
+      name = "status-renamed";
+      break;
+  }
+  if (name === undefined) {
+    return undefined;
+  }
+  return getIconObject(name);
+}
+
 export async function copyCommitToClipboard(what: string, item: ILogTreeItem) {
   const clipboard = (env as any).clipboard;
   if (clipboard === undefined) {

--- a/src/historyView/itemLogProvider.ts
+++ b/src/historyView/itemLogProvider.ts
@@ -29,7 +29,8 @@ import {
   openDiff,
   openFileRemote,
   transform,
-  getCommitDescription
+  getCommitDescription,
+  SvnPath
 } from "./common";
 
 export class ItemLogProvider
@@ -54,6 +55,10 @@ export class ItemLogProvider
       commands.registerCommand(
         "svn.itemlog.copyrevision",
         async (item: ILogTreeItem) => copyCommitToClipboard("revision", item)
+      ),
+      commands.registerCommand(
+        "svn.itemlog.addrevision",
+        async (item: ILogTreeItem) => commands.executeCommand("svn.revisionviewer.addrevision", item)
       ),
       commands.registerCommand(
         "svn.itemlog.openFileRemote",
@@ -189,7 +194,14 @@ export class ItemLogProvider
       if (entries.length === 0) {
         await fetchMore(this.currentItem);
       }
-      const result = transform(entries, LogTreeItemKind.Commit);
+
+      // Assign repo as parent for RevisionViewerProvider
+      let repoParent: ILogTreeItem = {
+        kind: LogTreeItemKind.Repo,
+        data: new SvnPath(this.currentItem.repo.branchRoot.toString())
+      }
+
+      const result = transform(entries, LogTreeItemKind.Commit, repoParent);
       insertBaseMarker(this.currentItem, entries, result);
       if (!this.currentItem.isComplete) {
         const ti = new TreeItem(`Load another ${getLimit()} revisions`);

--- a/src/historyView/itemLogProvider.ts
+++ b/src/historyView/itemLogProvider.ts
@@ -58,7 +58,8 @@ export class ItemLogProvider
       ),
       commands.registerCommand(
         "svn.itemlog.addrevision",
-        async (item: ILogTreeItem) => commands.executeCommand("svn.revisionviewer.addrevision", item)
+        async (item: ILogTreeItem) =>
+          commands.executeCommand("svn.revisionviewer.addrevision", item)
       ),
       commands.registerCommand(
         "svn.itemlog.openFileRemote",
@@ -196,10 +197,10 @@ export class ItemLogProvider
       }
 
       // Assign repo as parent for RevisionViewerProvider
-      let repoParent: ILogTreeItem = {
+      const repoParent: ILogTreeItem = {
         kind: LogTreeItemKind.Repo,
         data: new SvnPath(this.currentItem.repo.branchRoot.toString())
-      }
+      };
 
       const result = transform(entries, LogTreeItemKind.Commit, repoParent);
       insertBaseMarker(this.currentItem, entries, result);

--- a/src/historyView/repoLogProvider.ts
+++ b/src/historyView/repoLogProvider.ts
@@ -41,8 +41,6 @@ import {
   transform,
   getCommitDescription
 } from "./common";
-import { resolve } from "dns";
-import { timingSafeEqual } from "crypto";
 
 export class RepoLogProvider
   implements TreeDataProvider<ILogTreeItem>, Disposable {
@@ -278,13 +276,21 @@ export class RepoLogProvider
     }
 
     // Confirm commit
-    let commit = (await repo.log(revision, revision, 1))[0];
+    let commit : ISvnLogEntry;
+    try {
+      commit = (await repo.log(revision, revision, 1, repo.branchRoot))[0];
+      
+    } catch (e) {
+      window.showErrorMessage(`Unable to fetch ${repo.branchRoot} r${revision}`);
+      return;
+    }
+
     if(! await window.showQuickPick(
       [{label: commit.msg}],
       )){
         return;
       }
-    
+
     // Create tree item
     let ti : ILogTreeItem = {
       kind: LogTreeItemKind.Commit,

--- a/src/historyView/repoLogProvider.ts
+++ b/src/historyView/repoLogProvider.ts
@@ -29,6 +29,7 @@ import {
   getCommitLabel,
   getCommitToolTip,
   getIconObject,
+  getActionIcon,
   getLimit,
   ICachedLog,
   ILogTreeItem,
@@ -40,28 +41,6 @@ import {
   transform,
   getCommitDescription
 } from "./common";
-
-function getActionIcon(action: string) {
-  let name: string | undefined;
-  switch (action) {
-    case "A":
-      name = "status-added";
-      break;
-    case "D":
-      name = "status-deleted";
-      break;
-    case "M":
-      name = "status-modified";
-      break;
-    case "R":
-      name = "status-renamed";
-      break;
-  }
-  if (name === undefined) {
-    return undefined;
-  }
-  return getIconObject(name);
-}
 
 export class RepoLogProvider
   implements TreeDataProvider<ILogTreeItem>, Disposable {
@@ -95,6 +74,10 @@ export class RepoLogProvider
         async (item: ILogTreeItem) => copyCommitToClipboard("revision", item)
       ),
       commands.registerCommand(
+        "svn.repolog.addrevision",
+        async (element: ILogTreeItem) => commands.executeCommand("svn.revisionviewer.addrevision", element)
+      ),
+      commands.registerCommand(
         "svn.repolog.addrepolike",
         this.addRepolikeGui,
         this
@@ -117,7 +100,7 @@ export class RepoLogProvider
           return this.refresh();
           // TODO refresh only required repo, need to pass element === getChildren()
         }
-      )
+      ),
     );
   }
 

--- a/src/historyView/repoLogProvider.ts
+++ b/src/historyView/repoLogProvider.ts
@@ -75,7 +75,8 @@ export class RepoLogProvider
       ),
       commands.registerCommand(
         "svn.repolog.addrevision",
-        async (element: ILogTreeItem) => commands.executeCommand("svn.revisionviewer.addrevision", element)
+        async (element: ILogTreeItem) =>
+          commands.executeCommand("svn.revisionviewer.addrevision", element)
       ),
       commands.registerCommand(
         "svn.repolog.addrepolike",
@@ -242,19 +243,17 @@ export class RepoLogProvider
         .map(repoPath => {
           const cached: ICachedLog = this.logCache.get(repoPath)!;
           if (cached.repo instanceof Repository) {
-            return {label: `$(folder) ${repoPath}`, repo: cached.repo};
+            return { label: `$(folder) ${repoPath}`, repo: cached.repo };
           } else {
-            return {label: `$(repo) ${repoPath}`, repo: cached.repo};
+            return { label: `$(repo) ${repoPath}`, repo: cached.repo };
           }
         });
 
-      const item = await window.showQuickPick(
-        items,
-        { placeHolder: "Which repository?"}
-      );
+      const item = await window.showQuickPick(items, {
+        placeHolder: "Which repository?"
+      });
 
-      if (item)
-        repo = item.repo;
+      if (item) repo = item.repo;
     } else {
       repo = this.logCache.entries().next().value[1].repo;
     }
@@ -263,36 +262,33 @@ export class RepoLogProvider
       return;
     }
 
-    // Get revision 
+    // Get revision
     const input = await window.showInputBox({ prompt: "Revision?" });
     if (!input) {
       return;
     }
 
-    let revision = getRevision(input)?.toString();
+    const revision = getRevision(input)?.toString();
     if (!revision) {
       window.showErrorMessage("Invalid revision");
       return;
     }
 
     // Confirm commit
-    let commit : ISvnLogEntry;
+    let commit: ISvnLogEntry;
     try {
       commit = (await repo.log(revision, revision, 1, repo.branchRoot))[0];
-      
     } catch (e) {
-      window.showErrorMessage(`Unable to fetch ${repo.branchRoot} r${revision}`);
+      window.showErrorMessage(
+        `Unable to fetch ${repo.branchRoot} r${revision}`
+      );
       return;
     }
 
-    if(! await window.showQuickPick(
-      [{label: commit.msg}],
-      )){
-        return;
-      }
+    if (!(await window.showQuickPick([{ label: commit.msg }]))) return;
 
     // Create tree item
-    let ti : ILogTreeItem = {
+    const ti: ILogTreeItem = {
       kind: LogTreeItemKind.Commit,
       data: commit,
       parent: {

--- a/src/historyView/revisionViewerProvider.ts
+++ b/src/historyView/revisionViewerProvider.ts
@@ -1,0 +1,136 @@
+import * as path from "path";
+import {
+  commands,
+  Disposable,
+  Event,
+  EventEmitter,
+  TreeDataProvider,
+  TreeItem,
+  TreeItemCollapsibleState,
+  window
+} from "vscode";
+import { ISvnLogEntry, ISvnLogEntryPath } from "../common/types";
+import { dispose } from "../util";
+import {
+  getCommitIcon,
+  getCommitLabel,
+  getCommitToolTip,
+  getIconObject,
+  ILogTreeItem,
+  LogTreeItemKind,
+  transform,
+  getCommitDescription,
+  SvnPath,
+  getActionIcon
+} from "./common";
+
+export class RevisionViewerProvider
+  implements TreeDataProvider<ILogTreeItem>, Disposable {
+  private _onDidChangeTreeData: EventEmitter<
+    ILogTreeItem | undefined
+  > = new EventEmitter<ILogTreeItem | undefined>();
+  public readonly onDidChangeTreeData: Event<ILogTreeItem | undefined> = this
+    ._onDidChangeTreeData.event;
+  private readonly logCache: Map<string, ISvnLogEntry[]> = new Map();
+  private _dispose: Disposable[] = [];
+
+  constructor() {
+    this._dispose.push(
+      window.registerTreeDataProvider("revisionviewer", this),
+      commands.registerCommand(
+        "svn.revisionviewer.addrevision",
+        this.addRevision,
+        this
+      ),
+    );
+  }
+
+  public dispose() {
+    dispose(this._dispose);
+  }
+
+  public async addRevision(element?: ILogTreeItem) {
+    if (!element) {
+        // TODO invoked from command palette
+        // window.showInformationMessage("Nothing specified");
+        return ;
+    }
+
+    const svnTarget = element.parent!.data as SvnPath;
+    const repoPath = svnTarget.toString();
+    const logEntry = element.data as ISvnLogEntry;
+
+    if (this.logCache.has(repoPath)) {
+        this.logCache.get(repoPath)!.push(logEntry)
+    } else {
+        this.logCache.set(repoPath, [logEntry]);
+    }
+    
+    this._onDidChangeTreeData.fire();
+  }
+
+  public async getTreeItem(element: ILogTreeItem): Promise<TreeItem> {
+    let ti: TreeItem;
+    if (element.kind === LogTreeItemKind.Repo) {
+      const svnTarget = element.data as SvnPath;
+      ti = new TreeItem(
+        svnTarget.toString(),
+        TreeItemCollapsibleState.Expanded
+      );
+      ti.contextValue = "viewerrepo"
+      ti.iconPath = getIconObject("icon-repo");
+    } else if (element.kind === LogTreeItemKind.Commit) {
+      const commit = element.data as ISvnLogEntry;
+      ti = new TreeItem(
+        getCommitLabel(commit),
+        TreeItemCollapsibleState.Collapsed
+      );
+      ti.description = getCommitDescription(commit);
+      ti.tooltip = getCommitToolTip(commit);
+      ti.iconPath = getCommitIcon(commit.author);
+      ti.contextValue = "commit";
+    } else if (element.kind === LogTreeItemKind.CommitDetail) {
+      // TODO optional tree-view instead of flat
+      const pathElem = element.data as ISvnLogEntryPath;
+      const basename = path.basename(pathElem._);
+      ti = new TreeItem(basename, TreeItemCollapsibleState.None);
+      ti.description = path.dirname(pathElem._);
+      ti.iconPath = getActionIcon(pathElem.action);
+      ti.contextValue = "diffable";
+      ti.command = {
+        command: "svn.repolog.openDiff",
+        title: "Open diff",
+        arguments: [element]
+      };
+    } else if (element.kind === LogTreeItemKind.TItem) {
+      ti = element.data as TreeItem;
+    } else {
+      throw new Error("Unknown tree elem");
+    }
+
+    return ti;
+  }
+
+  public async getChildren(
+    element: ILogTreeItem | undefined
+  ): Promise<ILogTreeItem[]> {
+    if (element === undefined) {
+      return transform(
+        [...this.logCache.keys()].map((path: string) => new SvnPath(path)),
+        LogTreeItemKind.Repo
+      );
+    } else if (element.kind === LogTreeItemKind.Repo) {
+      let repo = element.data as SvnPath;
+      let repoPath = repo.toString();
+
+      if (this.logCache.has(repoPath)) {
+        let logentries = this.logCache.get(repoPath)!;
+        return transform(logentries, LogTreeItemKind.Commit, element);
+      }
+    } else if (element.kind === LogTreeItemKind.Commit) {
+      const commit = element.data as ISvnLogEntry;
+      return transform(commit.paths, LogTreeItemKind.CommitDetail, element);
+    }
+    return [];
+  }
+}

--- a/src/historyView/revisionViewerProvider.ts
+++ b/src/historyView/revisionViewerProvider.ts
@@ -49,13 +49,7 @@ export class RevisionViewerProvider
     dispose(this._dispose);
   }
 
-  public async addRevision(element?: ILogTreeItem) {
-    if (!element) {
-        // TODO invoked from command palette
-        // window.showInformationMessage("Nothing specified");
-        return ;
-    }
-
+  public async addRevision(element: ILogTreeItem) {
     const svnTarget = element.parent!.data as SvnPath;
     const repoPath = svnTarget.toString();
     const logEntry = element.data as ISvnLogEntry;

--- a/src/historyView/revisionViewerProvider.ts
+++ b/src/historyView/revisionViewerProvider.ts
@@ -31,7 +31,7 @@ export class RevisionViewerProvider
   > = new EventEmitter<ILogTreeItem | undefined>();
   public readonly onDidChangeTreeData: Event<ILogTreeItem | undefined> = this
     ._onDidChangeTreeData.event;
-  private readonly logCache: Map<string, Map<string,ISvnLogEntry>> = new Map();
+  private readonly logCache: Map<string, Map<string, ISvnLogEntry>> = new Map();
   private _dispose: Disposable[] = [];
 
   constructor() {
@@ -51,7 +51,7 @@ export class RevisionViewerProvider
         "svn.revisionviewer.removeall",
         this.removeAllCmd,
         this
-      ),
+      )
     );
   }
 
@@ -66,23 +66,21 @@ export class RevisionViewerProvider
 
     // Prevent duplicate revisions from being added
     if (this.logCache.has(repoPath)) {
-      const cache = this.logCache.get(repoPath)!
-      if(!cache.has(logEntry.revision)) 
-        cache.set(logEntry.revision, logEntry);
+      const cache = this.logCache.get(repoPath)!;
+      if (!cache.has(logEntry.revision)) cache.set(logEntry.revision, logEntry);
     } else {
       const cache: Map<string, ISvnLogEntry> = new Map();
       cache.set(logEntry.revision, logEntry);
       this.logCache.set(repoPath, cache);
     }
-    
+
     this._onDidChangeTreeData.fire();
   }
 
   public removeCmd(element: ILogTreeItem) {
-    if(element.kind == LogTreeItemKind.Repo) {
+    if (element.kind == LogTreeItemKind.Repo) {
       const repoPath = (element.data as SvnPath).toString();
       this.logCache.delete(repoPath);
-
     } else if (element.kind == LogTreeItemKind.Commit) {
       const revision = (element.data as ISvnLogEntry).revision;
       const repoPath = (element.parent?.data as SvnPath).toString();
@@ -91,7 +89,7 @@ export class RevisionViewerProvider
         entries.delete(revision);
 
         // Was this the last revision from this repo?
-        if (!entries.size)  {
+        if (!entries.size) {
           this.logCache.delete(repoPath);
         }
       }
@@ -113,7 +111,7 @@ export class RevisionViewerProvider
         svnTarget.toString(),
         TreeItemCollapsibleState.Expanded
       );
-      ti.contextValue = "repo"
+      ti.contextValue = "repo";
       ti.iconPath = getIconObject("icon-repo");
     } else if (element.kind === LogTreeItemKind.Commit) {
       const commit = element.data as ISvnLogEntry;
@@ -156,12 +154,14 @@ export class RevisionViewerProvider
         LogTreeItemKind.Repo
       );
     } else if (element.kind === LogTreeItemKind.Repo) {
-      let repo = element.data as SvnPath;
-      let repoPath = repo.toString();
+      const repo = element.data as SvnPath;
+      const repoPath = repo.toString();
 
       if (this.logCache.has(repoPath)) {
-        let logentries = Array.from(this.logCache.get(repoPath)!.entries())
-          .map(([_, entry ]) => entry);
+        const logentries = Array.from(
+          this.logCache.get(repoPath)!.entries()
+        ).map(([_, entry]) => entry);
+
         return transform(logentries, LogTreeItemKind.Commit, element);
       }
     } else if (element.kind === LogTreeItemKind.Commit) {

--- a/src/svnRepository.ts
+++ b/src/svnRepository.ts
@@ -196,6 +196,7 @@ export class Repository {
     let args = [
       "log",
       "-r1:HEAD",
+      "--limit=1",
       "--stop-on-copy",
       "--xml",
       "--with-all-revprops",

--- a/src/util.ts
+++ b/src/util.ts
@@ -228,7 +228,7 @@ export function pathEquals(a: string, b: string): boolean {
 export const EmptyDisposable = toDisposable(() => null);
 
 export function getRevision(text: string): number | undefined {
-  let exp = /^[\+r]?(0|[1-9]\d*)$/i;
+  const exp = /^[\+r]?(0|[1-9]\d*)$/i;
   if (!exp.test(text)) {
     return undefined;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -226,3 +226,12 @@ export function pathEquals(a: string, b: string): boolean {
 }
 
 export const EmptyDisposable = toDisposable(() => null);
+
+export function getRevision(text: string): number | undefined {
+  let exp = /^[\+r]?(0|[1-9]\d*)$/i;
+  if (!exp.test(text)) {
+    return undefined;
+  }
+
+  return parseInt(exp.exec(text)![1], 10);
+}


### PR DESCRIPTION
This pull request adds a new "Selected Revisions" TreeView to the SVN panel. This panel allows you to cherry pick revisions and view file diffs within that revision. You can select revisions from the Repositories or File History trees, or specifying any arbitrary revision from any currently added repository in the Repositories tree.

Examples of where this is useful:
- You're looking at the list of revisions that have modified `foo.c` in the File History view, but you'd like to know what other files those revisions may have modified as well. You would select that revision and view the complete change set. This provides the complete context of when `foo.c` was modified
- You want to look at all the changes made in a revision from a repository you've added, but is not the current Working Copy checkout. Example: 
  - Repo A references Repo B `r42` (commit message, file comment, documentation, etc)
  - Repo A is checked out and is the current working copy
  - Repo B is added in Repositories tree
  - You use the Selected Revisions tree to view the changes that Repo B `r42` introduced
- You want to look at an early revision without having to use the batched loading of the Repositories tree
- You've searched the log with the "SVN: Search..." commands and you've found an interesting revision that you want to see changes/diffs from

**Screenshot** 
<img width="529" alt="Screen Shot 2022-04-20 at 6 24 23 PM" src="https://user-images.githubusercontent.com/62858951/164357824-4beed402-9ec9-47b7-b0bd-c6edf2ad17fe.png">
