### PR TITLE
fix: bind repoWatch to RepositoryFilesWatcher object

### DIFF
--- a/src/watchers/repositoryFilesWatcher.ts
+++ b/src/watchers/repositoryFilesWatcher.ts
@@ -50,7 +50,7 @@ export class RepositoryFilesWatcher implements IDisposable {
       !workspace.workspaceFolders.filter(w => isDescendant(w.uri.fsPath, root))
         .length
     ) {
-      const repoWatcher = watch(join(root, getSvnDir()), this.repoWatch);
+      const repoWatcher = watch(join(root, getSvnDir()), this.repoWatch.bind(this));
 
       repoWatcher.on("error", error => {
         throw error;

--- a/src/watchers/repositoryFilesWatcher.ts
+++ b/src/watchers/repositoryFilesWatcher.ts
@@ -50,7 +50,10 @@ export class RepositoryFilesWatcher implements IDisposable {
       !workspace.workspaceFolders.filter(w => isDescendant(w.uri.fsPath, root))
         .length
     ) {
-      const repoWatcher = watch(join(root, getSvnDir()), this.repoWatch.bind(this));
+      const repoWatcher = watch(
+        join(root, getSvnDir()),
+        this.repoWatch.bind(this)
+      );
 
       repoWatcher.on("error", error => {
         throw error;


### PR DESCRIPTION
Currently, when files are changed, there is an exception that breaks the SVN extension.

```
2022-12-20 17:21:44.105 [error] TypeError: Cannot read properties of undefined (reading 'fire')
	at /home/mreisner/.vscode-server/extensions/johnstoncode.svn-scm-2.15.5/out/extension.js:2:278235
```

This pull request binds the call to `this.repoWatch` to the `RepositoryFilesWatcher` object so that this exception isn't triggered.